### PR TITLE
feat: add api_key, base_url params to ACELiteLLM

### DIFF
--- a/ace/integrations/litellm.py
+++ b/ace/integrations/litellm.py
@@ -103,10 +103,10 @@ class ACELiteLLM:
         model: str = "gpt-4o-mini",
         max_tokens: int = 2048,
         temperature: float = 0.0,
-        # Authentication & endpoint (Issue #33)
+        # Authentication & endpoint
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
-        # HTTP/SSL settings (Issue #33)
+        # HTTP/SSL settings
         extra_headers: Optional[Dict[str, str]] = None,
         ssl_verify: Optional[Union[bool, str]] = None,
         # ACE-specific settings
@@ -146,16 +146,16 @@ class ACELiteLLM:
             # Google
             agent = ACELiteLLM(model="gemini/gemini-pro")
 
-            # With explicit API key (Issue #33)
+            # With explicit API key
             agent = ACELiteLLM(model="gpt-4", api_key="sk-...")
 
-            # Custom endpoint - LM Studio, Ollama (Issue #33)
+            # Custom endpoint (LM Studio, Ollama)
             agent = ACELiteLLM(
                 model="openai/local-model",
                 base_url="http://localhost:1234/v1"
             )
 
-            # Enterprise with custom headers and SSL (Issue #33)
+            # Enterprise with custom headers and SSL
             agent = ACELiteLLM(
                 model="gpt-4",
                 base_url="https://proxy.company.com/v1",
@@ -196,7 +196,7 @@ class ACELiteLLM:
         else:
             self.playbook = Playbook()
 
-        # Create LLM client with configuration (Issue #33)
+        # Create LLM client with configuration
         self.llm = LiteLLMClient(
             model=model,
             max_tokens=max_tokens,

--- a/ace/llm_providers/litellm_client.py
+++ b/ace/llm_providers/litellm_client.py
@@ -64,7 +64,7 @@ class LiteLLMConfig:
     # Anthropic API limitation: temperature and top_p cannot both be specified
     sampling_priority: str = "temperature"  # "temperature" | "top_p" | "top_k"
 
-    # HTTP/SSL settings (Issue #33)
+    # HTTP/SSL settings
     extra_headers: Optional[Dict[str, str]] = None  # Custom HTTP headers
     ssl_verify: Optional[Union[bool, str]] = None  # True/False or path to CA bundle
 
@@ -440,7 +440,7 @@ class LiteLLMClient(LLMClient):
         if self.config.api_base:
             call_params["api_base"] = self.config.api_base
 
-        # Add HTTP/SSL settings (Issue #33)
+        # Add HTTP/SSL settings
         if self.config.extra_headers:
             call_params["extra_headers"] = self.config.extra_headers
         if self.config.ssl_verify is not None:
@@ -570,7 +570,7 @@ class LiteLLMClient(LLMClient):
         if self.config.api_base:
             call_params["api_base"] = self.config.api_base
 
-        # Add HTTP/SSL settings (Issue #33)
+        # Add HTTP/SSL settings
         if self.config.extra_headers:
             call_params["extra_headers"] = self.config.extra_headers
         if self.config.ssl_verify is not None:

--- a/examples/local-models/lm_studio_example.py
+++ b/examples/local-models/lm_studio_example.py
@@ -4,9 +4,6 @@ Test ACE with LM Studio (Ollama-compatible model).
 
 LM Studio runs an OpenAI-compatible API server, so we use the
 openai/ prefix with a custom base_url instead of ollama/.
-
-Note: Since Issue #33, you can pass base_url directly to ACELiteLLM
-instead of using environment variables.
 """
 
 from ace.integrations import ACELiteLLM
@@ -21,7 +18,7 @@ def main():
     lm_studio_url = "http://localhost:1234/v1"
 
     # 1. Create ACELiteLLM agent pointing to LM Studio
-    # Note: Use "openai/" prefix with base_url for LM Studio (Issue #33)
+    # Note: Use "openai/" prefix with base_url for LM Studio
     print(f"\n📡 Connecting to LM Studio at {lm_studio_url}...")
 
     playbook_path = Path("lm_studio_learned_strategies.json")
@@ -29,7 +26,7 @@ def main():
     try:
         agent = ACELiteLLM(
             model="openai/local-model",  # LM Studio serves any model as 'local-model'
-            base_url=lm_studio_url,  # Direct parameter (Issue #33) - no env var needed!
+            base_url=lm_studio_url,
             max_tokens=512,
             temperature=0.2,
             is_learning=True,

--- a/tests/test_litellm_client.py
+++ b/tests/test_litellm_client.py
@@ -249,7 +249,7 @@ class TestLiteLLMConfigDefaults(unittest.TestCase):
 
 @pytest.mark.unit
 class TestACELiteLLMConfiguration(unittest.TestCase):
-    """Test ACELiteLLM configuration parameter passing (Issue #33)."""
+    """Test ACELiteLLM configuration parameter passing."""
 
     def _mock_response(self):
         """Create mock LiteLLM response."""
@@ -334,21 +334,18 @@ class TestACELiteLLMConfiguration(unittest.TestCase):
 
         from ace.integrations import ACELiteLLM
 
-        # This should work exactly as before Issue #33
         agent = ACELiteLLM(model="gpt-4o-mini", max_tokens=1024, temperature=0.5)
         self.assertEqual(agent.model, "gpt-4o-mini")
         self.assertEqual(agent.llm.config.max_tokens, 1024)
         self.assertEqual(agent.llm.config.temperature, 0.5)
-        # New Issue #33 params should be None by default (before env var fallback)
-        # Note: api_key may be picked up from env vars by _setup_api_keys()
-        # which is existing behavior - backward compatible!
+        # New params should be None by default (api_key may be picked up from env vars)
         self.assertIsNone(agent.llm.config.extra_headers)
         self.assertIsNone(agent.llm.config.ssl_verify)
 
 
 @pytest.mark.unit
 class TestLiteLLMClientDirectConfig(unittest.TestCase):
-    """Test LiteLLMClient direct configuration (Issue #33)."""
+    """Test LiteLLMClient direct configuration."""
 
     def _mock_response(self):
         """Create mock LiteLLM response."""


### PR DESCRIPTION
## Summary
- Add direct parameter support for `api_key`, `base_url`, `extra_headers`, `ssl_verify`
- Enables enterprise use cases (custom endpoints, SSL certs, proxy headers)
- Full backward compatibility with existing code

Closes #33

## Changes
- **ACELiteLLM**: New params `api_key`, `base_url`, `extra_headers`, `ssl_verify`, `**llm_kwargs`
- **LiteLLMClient**: Added `extra_headers` and `ssl_verify` to config and API calls
- **Tests**: 11 new tests for parameter passing
- **Examples**: Updated `lm_studio_example.py` to use new params

## Test plan
- [x] Unit tests for api_key parameter passing
- [x] Unit tests for base_url → api_base mapping
- [x] Unit tests for extra_headers
- [x] Unit tests for ssl_verify (False and path)
- [x] Backward compatibility tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)