### PR TITLE
docs(examples): replace deprecated curate() with update_skills() across docs and examples

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -63,7 +63,7 @@ from ace import SkillManager
 
 skill_manager = SkillManager(client)
 
-skill_manager_output = skill_manager.curate(
+skill_manager_output = skill_manager.update_skills(
     reflection=reflection,
     skillbook=skillbook,
     question_context="Math problems",

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -127,7 +127,7 @@ reflection = reflector.reflect(
 )
 
 # Curate: Generate skillbook updates
-skill_manager_output = skill_manager.curate(
+skill_manager_output = skill_manager.update_skills(
     reflection=reflection,
     skillbook=skillbook,
     question_context=f"task: {task}",
@@ -227,7 +227,7 @@ class ACEWrapper:
         )
 
         # Curate
-        skill_manager_output = self.skill_manager.curate(
+        skill_manager_output = self.skill_manager.update_skills(
             reflection=reflection,
             skillbook=self.skillbook,
             question_context=f"task: {task}",
@@ -407,7 +407,7 @@ class ACEAPIAgent:
             feedback=feedback
         )
 
-        skill_manager_output = self.skill_manager.curate(
+        skill_manager_output = self.skill_manager.update_skills(
             reflection=reflection,
             skillbook=self.skillbook,
             question_context=f"API task: {task}",
@@ -518,7 +518,7 @@ class ACEWorkflowAgent:
             feedback=feedback
         )
 
-        skill_manager_output = self.skill_manager.curate(
+        skill_manager_output = self.skill_manager.update_skills(
             reflection=reflection,
             skillbook=self.skillbook,
             question_context=f"Multi-step workflow: {task}",
@@ -615,7 +615,7 @@ class ACEToolAgent:
             feedback=feedback
         )
 
-        skill_manager_output = self.skill_manager.curate(
+        skill_manager_output = self.skill_manager.update_skills(
             reflection=reflection,
             skillbook=self.skillbook,
             question_context=f"Tool-using task: {task}",
@@ -692,7 +692,7 @@ class ACEAsyncAgent:
             feedback=feedback
         )
 
-        skill_manager_output = self.skill_manager.curate(
+        skill_manager_output = self.skill_manager.update_skills(
             reflection=reflection,
             skillbook=self.skillbook,
             question_context=task,
@@ -787,7 +787,7 @@ class ACEChatAgent:
             feedback=feedback_text
         )
 
-        skill_manager_output = self.skill_manager.curate(
+        skill_manager_output = self.skill_manager.update_skills(
             reflection=reflection,
             skillbook=self.skillbook,
             question_context=f"Multi-turn conversation ({len(self.conversation_history)} turns)",
@@ -893,7 +893,7 @@ class ACEBatchAgent:
             feedback=feedback
         )
 
-        skill_manager_output = self.skill_manager.curate(
+        skill_manager_output = self.skill_manager.update_skills(
             reflection=reflection,
             skillbook=self.skillbook,
             question_context=f"Batch processing ({len(self.pending_results)} items)",
@@ -985,7 +985,7 @@ class ACEStreamingAgent:
             feedback=feedback
         )
 
-        skill_manager_output = self.skill_manager.curate(
+        skill_manager_output = self.skill_manager.update_skills(
             reflection=reflection,
             skillbook=self.skillbook,
             question_context=task,
@@ -1082,7 +1082,7 @@ class ACERobustAgent:
                 feedback=feedback
             )
 
-            skill_manager_output = self.skill_manager.curate(
+            skill_manager_output = self.skill_manager.update_skills(
                 reflection=reflection,
                 skillbook=self.skillbook,
                 question_context=f"Task ({'success' if success else 'failure'}): {task}",
@@ -1226,7 +1226,7 @@ def _learn(self, task: str, result):
         reflection = self.reflector.reflect(...)
 
         # Curation
-        curator_output = self.curator.curate(...)
+        skill_manager_output = self.skill_manager.update_skills(...)
 
         # Update
         self.skillbook.apply_update(skill_manager_output.update)

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -143,7 +143,7 @@ class TestReflectorSkillManager(unittest.TestCase):
     def test_curation(self):
         reflection = self.reflector.reflect(...)
 
-        skill_manager_output = self.skill_manager.curate(
+        skill_manager_output = self.skill_manager.update_skills(
             reflection=reflection,
             skillbook=self.skillbook,
             question_context="Math problem",

--- a/examples/custom_integration_example.py
+++ b/examples/custom_integration_example.py
@@ -98,7 +98,7 @@ class ACEWrappedAgent:
         )
 
         # Curate: Generate skillbook updates
-        skill_manager_output = self.skill_manager.curate(
+        skill_manager_output = self.skill_manager.update_skills(
             reflection=reflection,
             skillbook=self.skillbook,
             question_context=f"task: {task}\nfeedback: {feedback}",


### PR DESCRIPTION
This PR updates outdated references to the deprecated `skill_manager.curate()` API across the documentation and examples.

### Updated files
- `docs/API_REFERENCE.md`
- `docs/INTEGRATION_GUIDE.md`
- `docs/TESTING_GUIDE.md`
- `examples/custom_integration_example.py`

### What changed
All occurrences of:
```python
  skill_manager.curate(...)
```
were replaced with the updated API:
```python
  skill_manager.update_skills(...)
```

### Why
The library API transitioned from `curate()` to `update_skills()`, but several docs and example scripts still referenced the old function. This could confuse users and lead to errors when following the examples.

This PR updates all relevant documentation and examples to reflect the current API.

### Notes
- No production code changes.
- Only documentation and example updates.