### PR TITLE
Add reasoning_effort parameter support (#48)

### DIFF
--- a/tests/test_litellm_client.py
+++ b/tests/test_litellm_client.py
@@ -408,6 +408,48 @@ class TestLiteLLMClientDirectConfig(unittest.TestCase):
         call_kwargs = mock_completion.call_args[1]
         self.assertNotIn("ssl_verify", call_kwargs)
 
+    @patch("ace.llm_providers.litellm_client.completion")
+    def test_reasoning_effort_passed_through(self, mock_completion):
+        """Test reasoning_effort parameter is passed to LiteLLM (Issue #48)."""
+        mock_completion.return_value = self._mock_response()
+
+        from ace.llm_providers import LiteLLMClient
+
+        client = LiteLLMClient(model="gpt-5", reasoning_effort="low")
+        client.complete("Test prompt")
+
+        call_kwargs = mock_completion.call_args[1]
+        self.assertEqual(call_kwargs["reasoning_effort"], "low")
+
+    @patch("ace.llm_providers.litellm_client.completion")
+    def test_extra_params_multiple_values(self, mock_completion):
+        """Test multiple extra_params are passed to LiteLLM."""
+        mock_completion.return_value = self._mock_response()
+
+        from ace.llm_providers import LiteLLMClient
+
+        client = LiteLLMClient(
+            model="gpt-5",
+            reasoning_effort="high",
+            budget_tokens=10000,
+        )
+        client.complete("Test prompt")
+
+        call_kwargs = mock_completion.call_args[1]
+        self.assertEqual(call_kwargs["reasoning_effort"], "high")
+        self.assertEqual(call_kwargs["budget_tokens"], 10000)
+
+    @patch("ace.llm_providers.litellm_client.completion")
+    def test_extra_params_stored_in_config(self, mock_completion):
+        """Test extra_params are stored in config.extra_params."""
+        mock_completion.return_value = self._mock_response()
+
+        from ace.llm_providers import LiteLLMClient
+
+        client = LiteLLMClient(model="gpt-5", reasoning_effort="medium")
+
+        self.assertEqual(client.config.extra_params, {"reasoning_effort": "medium"})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Fixes #48: Users can now pass `reasoning_effort` parameter to `LiteLLMClient` for GPT-5 models
- Added `extra_params` field to `LiteLLMConfig` to capture model-specific parameters
- Parameters like `reasoning_effort`, `budget_tokens`, etc. are now passed through to LiteLLM

## Usage
```python
from ace.llm_providers import LiteLLMClient

client = LiteLLMClient(
    model="gpt-5",
    reasoning_effort="low",
    max_tokens=2048
)
```

## Test plan
- [x] Added unit tests for `reasoning_effort` parameter
- [x] Added tests for multiple extra params
- [x] Verified existing config fields (`extra_headers`, `ssl_verify`, `timeout`) still work
- [x] All 27 LiteLLM client tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)