### PR TITLE
fix: replace bare excepts with Exception in browser_use integration

### DIFF
--- a/ace/integrations/browser_use.py
+++ b/ace/integrations/browser_use.py
@@ -306,14 +306,14 @@ class ACEAgent:
             output = (
                 history.final_result() if hasattr(history, "final_result") else ""
             ) or ""
-        except:
+        except (AttributeError, Exception):
             output = ""
 
         try:
             steps = (
                 history.number_of_steps() if hasattr(history, "number_of_steps") else 0
             )
-        except:
+        except (AttributeError, Exception):
             steps = 0
 
         # Extract rich trace data in CHRONOLOGICAL order


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in `ace/integrations/browser_use.py`.

**Problem:** Bare `except:` catches `BaseException` including `KeyboardInterrupt` and `SystemExit`, which can mask critical system signals and make debugging harder.

**Fix:** Use `except Exception:` to maintain the same error-handling behavior while allowing system exceptions to propagate correctly.

**Changes:** 2 sites in `browser_use.py` (lines 309, 316) — both are fallback handlers for optional browser history attributes.