### PR TITLE
fix: replace 30 bare excepts with except Exception

### DIFF
--- a/ace/integrations/browser_use.py
+++ b/ace/integrations/browser_use.py
@@ -306,14 +306,14 @@ class ACEAgent:
             output = (
                 history.final_result() if hasattr(history, "final_result") else ""
             ) or ""
-        except:
+        except Exception:
             output = ""
 
         try:
             steps = (
                 history.number_of_steps() if hasattr(history, "number_of_steps") else 0
             )
-        except:
+        except Exception:
             steps = 0
 
         # Extract rich trace data in CHRONOLOGICAL order

--- a/examples/browser-use/domain-checker/ace_domain_checker.py
+++ b/examples/browser-use/domain-checker/ace_domain_checker.py
@@ -362,7 +362,7 @@ async def check_single_domain(agent: ACEAgent, domain: str) -> dict:
                     actual_steps = len(history.action_names())
                 else:
                     actual_steps = 0  # Unknown - don't make up numbers
-            except:
+            except Exception:
                 actual_steps = 0  # Can't determine actual steps
 
             steps = actual_steps + timeout_steps
@@ -388,7 +388,7 @@ async def check_single_domain(agent: ACEAgent, domain: str) -> dict:
                     steps = len(history.action_names())
                 else:
                     steps = 0
-            except:
+            except Exception:
                 steps = 0
 
             total_steps += steps
@@ -478,7 +478,7 @@ async def main():
     try:
         configure_opik(project_name="ace-domain-checker")
         print("📊 Opik observability enabled")
-    except:
+    except Exception:
         print("📊 Opik not available, continuing without observability")
 
     print("\n🔍 ACE + Browser-Use Domain Checker")

--- a/examples/browser-use/domain-checker/ace_domain_checker_async.py
+++ b/examples/browser-use/domain-checker/ace_domain_checker_async.py
@@ -370,7 +370,7 @@ async def check_single_domain(agent: ACEAgent, domain: str) -> dict:
                     actual_steps = len(history.action_names())
                 else:
                     actual_steps = 0  # Unknown - don't make up numbers
-            except:
+            except Exception:
                 actual_steps = 0  # Can't determine actual steps
 
             steps = actual_steps + timeout_steps
@@ -396,7 +396,7 @@ async def check_single_domain(agent: ACEAgent, domain: str) -> dict:
                     steps = len(history.action_names())
                 else:
                     steps = 0
-            except:
+            except Exception:
                 steps = 0
 
             total_steps += steps
@@ -486,7 +486,7 @@ async def main():
     try:
         configure_opik(project_name="ace-domain-checker")
         print("📊 Opik observability enabled")
-    except:
+    except Exception:
         print("📊 Opik not available, continuing without observability")
 
     print("\n🔍 ACE + Browser-Use Domain Checker")

--- a/examples/browser-use/domain-checker/ace_domain_checker_sync.py
+++ b/examples/browser-use/domain-checker/ace_domain_checker_sync.py
@@ -369,7 +369,7 @@ async def check_single_domain(agent: ACEAgent, domain: str) -> dict:
                     actual_steps = len(history.action_names())
                 else:
                     actual_steps = 0  # Unknown - don't make up numbers
-            except:
+            except Exception:
                 actual_steps = 0  # Can't determine actual steps
 
             steps = actual_steps + timeout_steps
@@ -395,7 +395,7 @@ async def check_single_domain(agent: ACEAgent, domain: str) -> dict:
                     steps = len(history.action_names())
                 else:
                     steps = 0
-            except:
+            except Exception:
                 steps = 0
 
             total_steps += steps
@@ -485,7 +485,7 @@ async def main():
     try:
         configure_opik(project_name="ace-domain-checker")
         print("📊 Opik observability enabled")
-    except:
+    except Exception:
         print("📊 Opik not available, continuing without observability")
 
     print("\n🔍 ACE + Browser-Use Domain Checker")

--- a/examples/browser-use/domain-checker/baseline_domain_checker.py
+++ b/examples/browser-use/domain-checker/baseline_domain_checker.py
@@ -188,7 +188,7 @@ async def check_domain(domain: str, headless: bool = True):
                     actual_steps = len(history.action_names())
                 else:
                     actual_steps = 0  # Unknown - don't make up numbers
-            except:
+            except Exception:
                 actual_steps = 0  # Can't determine actual steps
 
             # Add timeout steps to actual steps
@@ -213,7 +213,7 @@ async def check_domain(domain: str, headless: bool = True):
                     steps = len(history.action_names())
                 else:
                     steps = 0
-            except:
+            except Exception:
                 steps = 0
 
             total_steps += steps
@@ -276,7 +276,7 @@ async def check_domain(domain: str, headless: bool = True):
             if browser:
                 try:
                     await browser.stop()
-                except:
+                except Exception:
                     pass
 
     # All retries failed - use accumulated tokens from all attempts

--- a/examples/browser-use/form-filler/ace_browser_use.py
+++ b/examples/browser-use/form-filler/ace_browser_use.py
@@ -150,7 +150,7 @@ class BrowserUseEnvironment(TaskEnvironment):
             is_successful = result.is_successful()
             has_errors = result.has_errors()
             number_of_steps = result.number_of_steps()
-        except:
+        except Exception:
             print("ERROR GETTING MODEL OUTPUTS: ", e)
             print("TYPE OF RESULT: ", type(result))
             print("RESULT: ", result)
@@ -240,7 +240,7 @@ class BrowserUseEnvironment(TaskEnvironment):
                         if hasattr(history, "number_of_steps")
                         else 25
                     )
-            except:
+            except Exception:
                 pass
             return {
                 "is_done": False,
@@ -259,7 +259,7 @@ class BrowserUseEnvironment(TaskEnvironment):
                         if hasattr(history, "number_of_steps")
                         else 0
                     )
-            except:
+            except Exception:
                 pass
             return {
                 "is_done": False,
@@ -273,7 +273,7 @@ class BrowserUseEnvironment(TaskEnvironment):
             if browser:
                 try:
                     await browser.stop()
-                except:
+                except Exception:
                     pass
 
     def _get_token_usage(self, trace_id: str = None) -> tuple[int, int, int, int]:
@@ -394,7 +394,7 @@ def main(task_file: str = "task2_form.txt"):
     try:
         configure_opik(project_name="ace-browser-use")
         print("📊 Opik observability enabled")
-    except:
+    except Exception:
         print("📊 Opik not available, continuing without observability")
 
     print("\n🤖 ACE Browser Agent (WITH ACE)")

--- a/examples/browser-use/form-filler/ace_form_filler.py
+++ b/examples/browser-use/form-filler/ace_form_filler.py
@@ -136,7 +136,7 @@ ERROR: <reason>"""
                     if "history" in locals() and hasattr(history, "number_of_steps")
                     else 0
                 )
-            except:
+            except Exception:
                 steps = 25  # max_steps if we can't determine
             return {"status": "ERROR", "steps": steps, "error": "Timeout"}
         except Exception as e:
@@ -147,14 +147,14 @@ ERROR: <reason>"""
                     if "history" in locals() and hasattr(history, "number_of_steps")
                     else 0
                 )
-            except:
+            except Exception:
                 steps = 0
             return {"status": "ERROR", "steps": steps, "error": str(e)}
         finally:
             if browser:
                 try:
                     await browser.stop()
-                except:
+                except Exception:
                     pass
 
 
@@ -165,7 +165,7 @@ def main():
     try:
         configure_opik(project_name="ace-browser-form-filler")
         print("📊 Opik observability enabled")
-    except:
+    except Exception:
         print("📊 Opik not available, continuing without observability")
 
     print("\n🚀 ACE + Browser-Use Form Filler")

--- a/examples/browser-use/form-filler/baseline_browser_use.py
+++ b/examples/browser-use/form-filler/baseline_browser_use.py
@@ -324,7 +324,7 @@ async def run_browser_task(
                 if "history" in locals() and hasattr(history, "number_of_steps")
                 else 0
             )
-        except:
+        except Exception:
             steps = 25  # max_steps if we can't determine
         return {"status": "ERROR", "steps": steps, "error": "Timeout", "success": False}
     except Exception as e:
@@ -335,14 +335,14 @@ async def run_browser_task(
                 if "history" in locals() and hasattr(history, "number_of_steps")
                 else 0
             )
-        except:
+        except Exception:
             steps = 0
         return {"status": "ERROR", "steps": steps, "error": str(e), "success": False}
     finally:
         if browser:
             try:
                 await browser.stop()
-            except:
+            except Exception:
                 pass
 
 

--- a/examples/browser-use/form-filler/baseline_form_filler.py
+++ b/examples/browser-use/form-filler/baseline_form_filler.py
@@ -83,7 +83,7 @@ ERROR: <reason>"""
                 if "history" in locals() and hasattr(history, "number_of_steps")
                 else 0
             )
-        except:
+        except Exception:
             steps = 25  # max_steps if we can't determine
         return {"status": "ERROR", "steps": steps, "error": "Timeout", "success": False}
     except Exception as e:
@@ -94,14 +94,14 @@ ERROR: <reason>"""
                 if "history" in locals() and hasattr(history, "number_of_steps")
                 else 0
             )
-        except:
+        except Exception:
             steps = 0
         return {"status": "ERROR", "steps": steps, "error": str(e), "success": False}
     finally:
         if browser:
             try:
                 await browser.stop()
-            except:
+            except Exception:
                 pass
 
 

--- a/examples/prompts/compare_v1_v2_prompts.py
+++ b/examples/prompts/compare_v1_v2_prompts.py
@@ -44,7 +44,7 @@ class ComparisonEnvironment(TaskEnvironment):
             expected = float(sample.ground_truth)
             actual = float(agent_output.final_answer)
             correct = abs(expected - actual) < 0.0001
-        except:
+        except Exception:
             # Fall back to text comparison
             correct = sample.ground_truth.lower() in agent_output.final_answer.lower()
 


### PR DESCRIPTION
## Summary

Replace 30 bare `except:` clauses with `except Exception:` across 10 files.

## Why

Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, which can mask real errors and prevent clean process termination. `except Exception:` preserves the intended error-suppression behavior while allowing system-level exceptions to propagate normally.

## Changes

- `ace/integrations/browser_use.py` (2 sites)
- `examples/browser-use/domain-checker/` (12 sites across 4 files)
- `examples/browser-use/form-filler/` (15 sites across 4 files)
- `examples/prompts/compare_v1_v2_prompts.py` (1 site)

All changes are minimal and behavior-preserving.