### PR TITLE
fix: force UTF-8 decoding for Claude Code CLI

### DIFF
--- a/ace/integrations/claude_code/cli_client.py
+++ b/ace/integrations/claude_code/cli_client.py
@@ -179,6 +179,7 @@ class CLIClient(LLMClient):
                     text=True,
                     timeout=self.timeout,
                     env=env,
+                    encoding='utf-8',
                 )
 
                 if result.returncode != 0:

--- a/ace/integrations/claude_code/learner.py
+++ b/ace/integrations/claude_code/learner.py
@@ -1151,6 +1151,7 @@ def cmd_doctor(_args):
                 capture_output=True,
                 text=True,
                 timeout=30,
+                encoding='utf-8',
             )
             if result.returncode == 0:
                 print("   ✓ CLI responds to ping")

--- a/ace/integrations/claude_code_cli.py
+++ b/ace/integrations/claude_code_cli.py
@@ -230,6 +230,7 @@ class ACEClaudeCode:
                 capture_output=True,
                 timeout=self.timeout,
                 env=env,
+                encoding='utf-8',
             )
 
             execution_trace, summary = self._parse_stream_json(result.stdout)


### PR DESCRIPTION
## Summary
- Ensure subprocess output is decoded as UTF-8 for Claude Code CLI integration on Windows.
- Adds explicit encoding to three subprocess.run call sites.

## Rationale
Windows default code pages (e.g., cp1252) can corrupt or fail when CLI emits UTF-8. Explicit UTF-8 avoids decode errors and garbled output.

## Files
- ace/integrations/claude_code/cli_client.py
- ace/integrations/claude_code/learner.py
- ace/integrations/claude_code_cli.py