### PR TITLE
feat(mcp): add optional ACE MCP server with session-scoped tools and …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to ACE Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.5] - 2026-03-02
+
+### Added
+- **ACE MCP server (optional)** — stdio MCP server in `ace_next.integrations.mcp` with tools: `ace.ask`, `ace.learn.sample`, `ace.learn.feedback`, `ace.skillbook.get`, `ace.skillbook.save`, `ace.skillbook.load`
+- **Session-scoped state management** — in-memory `session_id` registry with TTL cleanup and per-session async locking
+- **MCP packaging + CLI** — optional `mcp` extra and `ace-mcp` entrypoint
+- **MCP docs and demo client** — integration guide and stdio client example
+
+### Changed
+- **Safety controls** — runtime request limits (`max_prompt_chars`, `max_samples_per_call`) and optional root-bound path enforcement for save/load via `ACE_MCP_SKILLBOOK_ROOT`
+- **Schema-driven validation** — MCP request/response models aligned to `specs/002-ace-mcp-server/contracts/tool-schemas.md`
+
+### Testing
+- Added MCP test suite: models, registry, handlers, and server registration/startup smoke tests
+- Verified unit regression after MCP integration updates
+
 ## [0.8.4] - 2026-02-27
 
 ### Added

--- a/ace_next/integrations/mcp/__init__.py
+++ b/ace_next/integrations/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""ACE MCP Server Integration."""

--- a/ace_next/integrations/mcp/adapters.py
+++ b/ace_next/integrations/mcp/adapters.py
@@ -1,0 +1,90 @@
+import json
+import mcp.types as types
+from mcp.server import Server
+
+from ace_next.integrations.mcp.handlers import MCPHandlers
+from ace_next.integrations.mcp.models import (
+    AskRequest, LearnSampleRequest, LearnFeedbackRequest,
+    SkillbookGetRequest, SkillbookSaveRequest, SkillbookLoadRequest
+)
+from ace_next.integrations.mcp.errors import map_error_to_mcp
+
+def register_tools(server: Server, handlers: MCPHandlers) -> None:
+    @server.list_tools()
+    async def handle_list_tools() -> list[types.Tool]:
+        return [
+            types.Tool(
+                name="ace.ask",
+                description="Ask a question and get a response from ACE.",
+                inputSchema=AskRequest.model_json_schema()
+            ),
+            types.Tool(
+                name="ace.learn.sample",
+                description="Provide sample questions/answers for ACE to learn from.",
+                inputSchema=LearnSampleRequest.model_json_schema()
+            ),
+            types.Tool(
+                name="ace.learn.feedback",
+                description="Provide feedback on an ACE answer.",
+                inputSchema=LearnFeedbackRequest.model_json_schema()
+            ),
+            types.Tool(
+                name="ace.skillbook.get",
+                description="Get statistics and skills from the active skillbook.",
+                inputSchema=SkillbookGetRequest.model_json_schema()
+            ),
+            types.Tool(
+                name="ace.skillbook.save",
+                description="Save the active skillbook to disk.",
+                inputSchema=SkillbookSaveRequest.model_json_schema()
+            ),
+            types.Tool(
+                name="ace.skillbook.load",
+                description="Load a skillbook from disk into the session.",
+                inputSchema=SkillbookLoadRequest.model_json_schema()
+            )
+        ]
+
+    @server.call_tool()
+    async def handle_call_tool(name: str, arguments: dict | None) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource] | types.CallToolResult:
+        args = arguments or {}
+        try:
+            if name == "ace.ask":
+                req = AskRequest(**args)
+                resp = await handlers.handle_ask(req)
+                return [types.TextContent(type="text", text=resp.model_dump_json())]
+                
+            elif name == "ace.learn.sample":
+                req = LearnSampleRequest(**args)
+                resp = await handlers.handle_learn_sample(req)
+                return [types.TextContent(type="text", text=resp.model_dump_json())]
+                
+            elif name == "ace.learn.feedback":
+                req = LearnFeedbackRequest(**args)
+                resp = await handlers.handle_learn_feedback(req)
+                return [types.TextContent(type="text", text=resp.model_dump_json())]
+                
+            elif name == "ace.skillbook.get":
+                req = SkillbookGetRequest(**args)
+                resp = await handlers.handle_skillbook_get(req)
+                return [types.TextContent(type="text", text=resp.model_dump_json())]
+                
+            elif name == "ace.skillbook.save":
+                req = SkillbookSaveRequest(**args)
+                resp = await handlers.handle_skillbook_save(req)
+                return [types.TextContent(type="text", text=resp.model_dump_json())]
+                
+            elif name == "ace.skillbook.load":
+                req = SkillbookLoadRequest(**args)
+                resp = await handlers.handle_skillbook_load(req)
+                return [types.TextContent(type="text", text=resp.model_dump_json())]
+                
+            else:
+                raise ValueError(f"Unknown tool: {name}")
+                
+        except Exception as e:
+            mcp_err = map_error_to_mcp(e)
+            return types.CallToolResult(
+                isError=True,
+                content=[types.TextContent(type="text", text=json.dumps(mcp_err))]
+            )

--- a/ace_next/integrations/mcp/config.py
+++ b/ace_next/integrations/mcp/config.py
@@ -1,0 +1,19 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import Field
+
+class MCPServerConfig(BaseSettings):
+    """Configuration for the ACE MCP Server."""
+    
+    default_model: str = Field(default="gpt-4o-mini")
+    safe_mode: bool = Field(default=False)
+    max_samples_per_call: int = Field(default=25)
+    max_prompt_chars: int = Field(default=100_000)
+    session_ttl_seconds: int = Field(default=3600)
+    allow_save_load: bool = Field(default=True)
+    skillbook_root: str | None = Field(default=None)
+    log_level: str = Field(default="INFO")
+
+    model_config = SettingsConfigDict(
+        env_prefix="ACE_MCP_",
+        case_sensitive=False,
+    )

--- a/ace_next/integrations/mcp/errors.py
+++ b/ace_next/integrations/mcp/errors.py
@@ -1,0 +1,45 @@
+class ACEMCPError(Exception):
+    """Base exception for ACE MCP extensions."""
+    
+    def __init__(self, message: str, code: str, details: dict | None = None):
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.details = details or {}
+
+class ValidationError(ACEMCPError):
+    def __init__(self, message: str, details: dict | None = None):
+        super().__init__(message, "ACE_MCP_VALIDATION_ERROR", details)
+
+class SessionNotFoundError(ACEMCPError):
+    def __init__(self, session_id: str):
+        super().__init__(f"Session not found: {session_id}", "ACE_MCP_SESSION_NOT_FOUND", {"session_id": session_id})
+
+class ForbiddenInSafeModeError(ACEMCPError):
+    def __init__(self, tool_name: str):
+        super().__init__(f"Tool {tool_name} is forbidden in safe mode", "ACE_MCP_FORBIDDEN_IN_SAFE_MODE", {"tool_name": tool_name})
+
+class ProviderError(ACEMCPError):
+    def __init__(self, message: str, details: dict | None = None):
+        super().__init__(message, "ACE_MCP_PROVIDER_ERROR", details)
+
+class TimeoutError(ACEMCPError):
+    def __init__(self, message: str = "Operation timed out"):
+        super().__init__(message, "ACE_MCP_TIMEOUT")
+
+class InternalError(ACEMCPError):
+    def __init__(self, message: str, details: dict | None = None):
+        super().__init__(message, "ACE_MCP_INTERNAL_ERROR", details)
+
+def map_error_to_mcp(err: Exception) -> dict:
+    if isinstance(err, ACEMCPError):
+        return {
+            "code": err.code,
+            "message": err.message,
+            "details": err.details
+        }
+    return {
+        "code": "ACE_MCP_INTERNAL_ERROR",
+        "message": f"An unexpected error occurred: {str(err)}",
+        "details": {"type": type(err).__name__}
+    }

--- a/ace_next/integrations/mcp/handlers.py
+++ b/ace_next/integrations/mcp/handlers.py
@@ -1,0 +1,277 @@
+from typing import Any
+import asyncio
+from pathlib import Path
+
+from ace_next.integrations.mcp.registry import SessionRegistry
+from ace_next.integrations.mcp.models import (
+    AskRequest, AskResponse,
+    LearnSampleRequest, LearnSampleResponse,
+    LearnFeedbackRequest, LearnFeedbackResponse,
+    SkillbookGetRequest, SkillbookGetResponse,
+    SkillbookSaveRequest, SkillbookSaveResponse,
+    SkillbookLoadRequest, SkillbookLoadResponse,
+    SkillItem
+)
+from ace_next.integrations.mcp.config import MCPServerConfig
+from ace_next.integrations.mcp.errors import (
+    ACEMCPError,
+    ForbiddenInSafeModeError,
+    InternalError,
+    ValidationError,
+)
+from ace_next.core.environments import Sample
+
+class MCPHandlers:
+    def __init__(self, registry: SessionRegistry, config: MCPServerConfig):
+        self.registry = registry
+        self.config = config
+
+    async def _get_session_kwargs(self, config_model) -> tuple[str | None, dict[str, Any]]:
+        target_model = None
+        kwargs: dict[str, Any] = {}
+        if config_model:
+            target_model = config_model.model  # may be None per contract
+            if config_model.temperature is not None:
+                kwargs["temperature"] = config_model.temperature
+            if config_model.max_tokens is not None:
+                kwargs["max_tokens"] = config_model.max_tokens
+        return target_model, kwargs
+
+    def _enforce_prompt_limit(self, char_count: int, field_name: str) -> None:
+        if char_count > self.config.max_prompt_chars:
+            raise ValidationError(
+                f"{field_name} exceeds max_prompt_chars ({self.config.max_prompt_chars})",
+                details={
+                    "field": field_name,
+                    "char_count": char_count,
+                    "max_prompt_chars": self.config.max_prompt_chars,
+                },
+            )
+
+    def _validate_skillbook_path(self, path: str) -> None:
+        if not self.config.skillbook_root:
+            return
+
+        root = Path(self.config.skillbook_root).expanduser().resolve()
+        target = Path(path).expanduser().resolve()
+        try:
+            target.relative_to(root)
+        except ValueError as exc:
+            raise ValidationError(
+                "Path is outside configured skillbook_root",
+                details={
+                    "path": str(target),
+                    "skillbook_root": str(root),
+                },
+            ) from exc
+
+    async def handle_ask(self, request: AskRequest) -> AskResponse:
+        self._enforce_prompt_limit(len(request.question) + len(request.context), "ask")
+
+        target_model, kwargs = await self._get_session_kwargs(request.session_config)
+        session = await self.registry.get_or_create(request.session_id, model=target_model, **kwargs)
+        
+        async with session.lock:
+            try:
+                answer = await asyncio.to_thread(session.runner.ask, request.question, request.context)
+                
+                applied_skill_ids = []
+                skill_count = len(session.runner.skillbook.skills())
+                
+                return AskResponse(
+                    session_id=request.session_id,
+                    answer=str(answer),
+                    skill_count=skill_count,
+                    applied_skill_ids=applied_skill_ids
+                )
+            except ACEMCPError:
+                raise
+            except Exception as e:
+                raise InternalError(str(e))
+
+    async def handle_skillbook_get(self, request: SkillbookGetRequest) -> SkillbookGetResponse:
+        session = await self.registry.get(request.session_id)
+        
+        async with session.lock:
+            try:
+                skillbook = session.runner.skillbook
+                skills = skillbook.skills(include_invalid=request.include_invalid)
+                
+                limited_skills = []
+                for s in skills:
+                    s_id = getattr(s, 'id', str(len(limited_skills)))
+                    s_content = getattr(s, 'content', str(s))
+                    s_topic = getattr(s, 'section', None)
+                    s_helpful = getattr(s, 'helpful', None)
+                    s_harmful = getattr(s, 'harmful', None)
+                    s_neutral = getattr(s, 'neutral', None)
+                    
+                    limited_skills.append(SkillItem(
+                        id=str(s_id),
+                        content=str(s_content),
+                        topic=str(s_topic) if s_topic else None,
+                        helpful=int(s_helpful) if s_helpful is not None else None,
+                        harmful=int(s_harmful) if s_harmful is not None else None,
+                        neutral=int(s_neutral) if s_neutral is not None else None
+                    ))
+                
+                limited_skills = limited_skills[:request.limit]
+                
+                stats = skillbook.stats()
+                
+                return SkillbookGetResponse(
+                    session_id=request.session_id,
+                    stats=stats,
+                    skills=limited_skills
+                )
+            except ACEMCPError:
+                raise
+            except Exception as e:
+                raise InternalError(str(e))
+
+    async def handle_learn_sample(self, request: LearnSampleRequest) -> LearnSampleResponse:
+        if self.config.safe_mode:
+            raise ForbiddenInSafeModeError("ace.learn.sample")
+
+        if len(request.samples) > self.config.max_samples_per_call:
+            raise ValidationError(
+                f"samples exceeds max_samples_per_call ({self.config.max_samples_per_call})",
+                details={
+                    "sample_count": len(request.samples),
+                    "max_samples_per_call": self.config.max_samples_per_call,
+                },
+            )
+
+        for idx, s in enumerate(request.samples, start=1):
+            self._enforce_prompt_limit(
+                len(s.question) + len(s.context),
+                f"samples[{idx}]",
+            )
+            
+        target_model, kwargs = await self._get_session_kwargs(request.session_config)
+        session = await self.registry.get_or_create(request.session_id, model=target_model, **kwargs)
+        
+        async with session.lock:
+            try:
+                samples = []
+                for s in request.samples:
+                    samples.append(Sample(
+                        question=s.question,
+                        context=s.context,
+                        ground_truth=s.ground_truth,
+                        metadata=s.metadata or {}
+                    ))
+                    
+                count_before = len(session.runner.skillbook.skills())
+                
+                await asyncio.to_thread(
+                    session.runner.learn,
+                    samples,
+                    None,
+                    request.epochs,
+                )
+                
+                count_after = len(session.runner.skillbook.skills())
+                
+                return LearnSampleResponse(
+                    session_id=request.session_id,
+                    processed=len(samples),
+                    failed=0,
+                    skill_count_before=count_before,
+                    skill_count_after=count_after,
+                    new_skill_count=max(0, count_after - count_before)
+                )
+            except ACEMCPError:
+                raise
+            except Exception as e:
+                raise InternalError(str(e))
+
+    async def handle_learn_feedback(self, request: LearnFeedbackRequest) -> LearnFeedbackResponse:
+        if self.config.safe_mode:
+            raise ForbiddenInSafeModeError("ace.learn.feedback")
+
+        self._enforce_prompt_limit(
+            len(request.question)
+            + len(request.context)
+            + len(request.answer)
+            + len(request.feedback),
+            "learn.feedback",
+        )
+            
+        target_model, kwargs = await self._get_session_kwargs(request.session_config)
+        session = await self.registry.get_or_create(request.session_id, model=target_model, **kwargs)
+        
+        async with session.lock:
+            try:
+                count_before = len(session.runner.skillbook.skills())
+
+                trace = {
+                    "question": request.question,
+                    "reasoning": request.context,
+                    "answer": request.answer,
+                    "skill_ids": [],
+                    "feedback": request.feedback,
+                    "ground_truth": request.ground_truth,
+                }
+                
+                await asyncio.to_thread(session.runner.learn_from_traces, [trace])
+                
+                count_after = len(session.runner.skillbook.skills())
+                
+                return LearnFeedbackResponse(
+                    session_id=request.session_id,
+                    learned=True,
+                    skill_count_before=count_before,
+                    skill_count_after=count_after,
+                    new_skill_count=max(0, count_after - count_before)
+                )
+            except ACEMCPError:
+                raise
+            except Exception as e:
+                raise InternalError(str(e))
+
+    async def handle_skillbook_save(self, request: SkillbookSaveRequest) -> SkillbookSaveResponse:
+        if self.config.safe_mode or not self.config.allow_save_load:
+            raise ForbiddenInSafeModeError("ace.skillbook.save")
+
+        self._validate_skillbook_path(request.path)
+            
+        session = await self.registry.get(request.session_id)
+        
+        async with session.lock:
+            try:
+                await asyncio.to_thread(session.runner.save, request.path)
+                skill_count = len(session.runner.skillbook.skills())
+                
+                return SkillbookSaveResponse(
+                    session_id=request.session_id,
+                    path=request.path,
+                    saved_skill_count=skill_count
+                )
+            except ACEMCPError:
+                raise
+            except Exception as e:
+                raise InternalError(str(e))
+
+    async def handle_skillbook_load(self, request: SkillbookLoadRequest) -> SkillbookLoadResponse:
+        if self.config.safe_mode or not self.config.allow_save_load:
+            raise ForbiddenInSafeModeError("ace.skillbook.load")
+
+        self._validate_skillbook_path(request.path)
+            
+        session = await self.registry.get_or_create(request.session_id)
+        
+        async with session.lock:
+            try:
+                await asyncio.to_thread(session.runner.load, request.path)
+                skill_count = len(session.runner.skillbook.skills())
+                
+                return SkillbookLoadResponse(
+                    session_id=request.session_id,
+                    path=request.path,
+                    skill_count=skill_count
+                )
+            except ACEMCPError:
+                raise
+            except Exception as e:
+                raise InternalError(str(e))

--- a/ace_next/integrations/mcp/models.py
+++ b/ace_next/integrations/mcp/models.py
@@ -1,0 +1,131 @@
+from typing import Any
+from pydantic import BaseModel, ConfigDict, Field
+
+class SessionConfig(BaseModel):
+    model: str | None = Field(default=None, min_length=1)
+    temperature: float | None = Field(default=None, ge=0, le=2)
+    max_tokens: int | None = Field(default=None, ge=1)
+    
+    model_config = ConfigDict(extra="forbid")
+
+class ErrorEnvelope(BaseModel):
+    code: str
+    message: str
+    details: dict[str, Any] | None = None
+    
+    model_config = ConfigDict(extra="forbid")
+
+class AskRequest(BaseModel):
+    session_id: str = Field(min_length=1)
+    question: str = Field(min_length=1, max_length=100000)
+    context: str = Field(default="")
+    session_config: SessionConfig | None = None
+    learn: bool = Field(default=True)
+    metadata: dict[str, Any] | None = None
+    
+    model_config = ConfigDict(extra="forbid")
+
+class AskResponse(BaseModel):
+    session_id: str
+    answer: str
+    skill_count: int = Field(ge=0)
+    applied_skill_ids: list[str] = Field(default_factory=list)
+    
+    model_config = ConfigDict(extra="forbid")
+
+class SampleItem(BaseModel):
+    question: str = Field(min_length=1)
+    context: str = Field(default="")
+    ground_truth: str | None = Field(default=None)
+    metadata: dict[str, Any] | None = None
+    
+    model_config = ConfigDict(extra="forbid")
+
+class LearnSampleRequest(BaseModel):
+    session_id: str = Field(min_length=1)
+    samples: list[SampleItem] = Field(min_length=1, max_length=25)
+    epochs: int = Field(default=1, ge=1, le=20)
+    session_config: SessionConfig | None = None
+    
+    model_config = ConfigDict(extra="forbid")
+
+class LearnSampleResponse(BaseModel):
+    session_id: str
+    processed: int = Field(ge=0)
+    failed: int = Field(default=0, ge=0)
+    skill_count_before: int = Field(ge=0)
+    skill_count_after: int = Field(ge=0)
+    new_skill_count: int = Field(ge=0)
+    
+    model_config = ConfigDict(extra="forbid")
+
+class LearnFeedbackRequest(BaseModel):
+    session_id: str = Field(min_length=1)
+    question: str = Field(min_length=1)
+    answer: str = Field(min_length=1)
+    feedback: str = Field(min_length=1)
+    context: str = Field(default="")
+    ground_truth: str | None = Field(default=None)
+    session_config: SessionConfig | None = None
+    
+    model_config = ConfigDict(extra="forbid")
+
+class LearnFeedbackResponse(BaseModel):
+    session_id: str
+    learned: bool
+    skill_count_before: int = Field(ge=0)
+    skill_count_after: int = Field(ge=0)
+    new_skill_count: int = Field(ge=0)
+    
+    model_config = ConfigDict(extra="forbid")
+
+class SkillbookGetRequest(BaseModel):
+    session_id: str = Field(min_length=1)
+    limit: int = Field(default=20, ge=1, le=200)
+    include_invalid: bool = Field(default=False)
+    
+    model_config = ConfigDict(extra="forbid")
+
+class SkillItem(BaseModel):
+    id: str
+    content: str
+    topic: str | None = None
+    helpful: int | None = None
+    harmful: int | None = None
+    neutral: int | None = None
+    
+    model_config = ConfigDict(extra="allow")
+
+class SkillbookGetResponse(BaseModel):
+    session_id: str
+    stats: dict[str, Any]
+    skills: list[SkillItem]
+    
+    model_config = ConfigDict(extra="forbid")
+
+class SkillbookSaveRequest(BaseModel):
+    session_id: str = Field(min_length=1)
+    path: str = Field(min_length=1)
+    
+    model_config = ConfigDict(extra="forbid")
+
+class SkillbookSaveResponse(BaseModel):
+    session_id: str
+    path: str
+    saved_skill_count: int = Field(ge=0)
+    
+    model_config = ConfigDict(extra="forbid")
+
+class SkillbookLoadRequest(BaseModel):
+    session_id: str = Field(min_length=1)
+    path: str = Field(min_length=1)
+    replace: bool = Field(default=True)
+    
+    model_config = ConfigDict(extra="forbid")
+
+class SkillbookLoadResponse(BaseModel):
+    session_id: str
+    path: str
+    skill_count: int = Field(ge=0)
+    
+    model_config = ConfigDict(extra="forbid")

--- a/ace_next/integrations/mcp/registry.py
+++ b/ace_next/integrations/mcp/registry.py
@@ -1,0 +1,69 @@
+import time
+import asyncio
+from dataclasses import dataclass, field
+from typing import Dict, Any
+
+from ace_next.runners import ACELiteLLM
+from ace_next.integrations.mcp.config import MCPServerConfig
+from ace_next.integrations.mcp.errors import SessionNotFoundError
+
+@dataclass
+class Session:
+    session_id: str
+    runner: ACELiteLLM
+    created_at: float = field(default_factory=time.time)
+    last_accessed: float = field(default_factory=time.time)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+class SessionRegistry:
+    def __init__(self, config: MCPServerConfig):
+        self.config = config
+        self._sessions: Dict[str, Session] = {}
+        self._registry_lock = asyncio.Lock()
+
+    async def get_or_create(self, session_id: str, model: str | None = None, **runner_kwargs: Any) -> Session:
+        """Get an existing session or create a new one, sweeping expired sessions first."""
+        await self._sweep_expired()
+        
+        async with self._registry_lock:
+            if session_id in self._sessions:
+                session = self._sessions[session_id]
+                session.last_accessed = time.time()
+                return session
+            
+            # Create new runner
+            target_model = model or self.config.default_model
+            runner = ACELiteLLM.from_model(target_model, **runner_kwargs)
+            session = Session(session_id=session_id, runner=runner)
+            self._sessions[session_id] = session
+            return session
+
+    async def get(self, session_id: str) -> Session:
+        """Get an existing session. Raises SessionNotFoundError if not found."""
+        await self._sweep_expired()
+        
+        async with self._registry_lock:
+            if session_id not in self._sessions:
+                raise SessionNotFoundError(session_id)
+            
+            session = self._sessions[session_id]
+            session.last_accessed = time.time()
+            return session
+
+    async def delete(self, session_id: str) -> None:
+        """Delete a session if it exists."""
+        async with self._registry_lock:
+            self._sessions.pop(session_id, None)
+
+    async def _sweep_expired(self) -> None:
+        """Remove sessions that have exceeded the TTL."""
+        now = time.time()
+        ttl = self.config.session_ttl_seconds
+        
+        async with self._registry_lock:
+            expired = [
+                sid for sid, session in self._sessions.items()
+                if now - session.last_accessed > ttl
+            ]
+            for sid in expired:
+                del self._sessions[sid]

--- a/ace_next/integrations/mcp/server.py
+++ b/ace_next/integrations/mcp/server.py
@@ -1,0 +1,52 @@
+import sys
+import asyncio
+import logging
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+
+from ace_next.integrations.mcp.config import MCPServerConfig
+from ace_next.integrations.mcp.registry import SessionRegistry
+from ace_next.integrations.mcp.handlers import MCPHandlers
+from ace_next.integrations.mcp.adapters import register_tools
+
+def create_server() -> Server:
+    config = MCPServerConfig()
+    
+    # Configure logging based on config.log_level
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=getattr(logging, config.log_level.upper(), logging.INFO),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    logger = logging.getLogger("ace_mcp_server")
+    logger.info("Starting ACE MCP Server...")
+    logger.info(f"Safe mode: {config.safe_mode}")
+    logger.info(f"Default model: {config.default_model}")
+    
+    registry = SessionRegistry(config)
+    handlers = MCPHandlers(registry, config)
+    
+    server = Server("ace-mcp-server")
+    register_tools(server, handlers)
+    
+    return server
+
+async def run_server() -> None:
+    try:
+        server = create_server()
+        async with stdio_server() as (read_stream, write_stream):
+            await server.run(
+                read_stream,
+                write_stream,
+                server.create_initialization_options()
+            )
+    except Exception as e:
+        print(f"Failed to start ACE MCP Server: {e}", file=sys.stderr)
+        sys.exit(1)
+
+def main() -> None:
+    """CLI Entrypoint for ace-mcp."""
+    asyncio.run(run_server())
+
+if __name__ == "__main__":
+    main()

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -1,0 +1,46 @@
+# ACE MCP Server
+
+ACE (Agentic Context Engine) provides an optional MCP server to allow orchestration frameworks, IDEs (like Cursor, Windsurf, Claude Code), and other clients to use ACE as a tool provider.
+
+## Installation
+
+To enable the MCP server, install ACE with the `mcp` extra:
+
+```bash
+pip install "ace-framework[mcp]"
+# or using uv:
+uv add "ace-framework[mcp]"
+```
+
+## Running the Server
+
+Start the server using the provided CLI command:
+
+```bash
+ace-mcp
+```
+
+By default it listens on standard out (`stdio`), making it ready for integration as a local tool provider. 
+
+## Configuration
+
+Set configuration via environment variables:
+
+- `ACE_MCP_DEFAULT_MODEL` (default: `gpt-4o-mini`): AI model used when new sessions are created.
+- `ACE_MCP_SAFE_MODE` (default: `false`): Disables mutating tools (learn, save, load) when set to `true`.
+- `ACE_MCP_MAX_SAMPLES_PER_CALL` (default: `25`): Limit for learning samples in one call.
+- `ACE_MCP_MAX_PROMPT_CHARS` (default: `100000`): Max limit for user prompt characters.
+- `ACE_MCP_SESSION_TTL_SECONDS` (default: `3600`): Time-to-live for idle sessions in memory.
+- `ACE_MCP_ALLOW_SAVE_LOAD` (default: `true`): If `false`, disables reading/writing skillbooks.
+- `ACE_MCP_SKILLBOOK_ROOT` (default: unset): If set, save/load paths must stay under this directory.
+
+## Tools Provided
+
+- `ace.ask`: Ask a question and get a response from ACE.
+- `ace.learn.sample`: Provide sample questions/answers for ACE to learn from.
+- `ace.learn.feedback`: Provide feedback on an ACE answer.
+- `ace.skillbook.get`: Get statistics and skills from the active skillbook.
+- `ace.skillbook.save`: Save the active skillbook to disk.
+- `ace.skillbook.load`: Load a skillbook from disk into the session.
+
+All state is isolated by `session_id`. Pass the same `session_id` continuously to persist context within the server memory.

--- a/examples/ace_next/mcp_client_demo.py
+++ b/examples/ace_next/mcp_client_demo.py
@@ -1,0 +1,61 @@
+import asyncio
+import os
+import sys
+from mcp.client.stdio import stdio_client
+from mcp.client.session import ClientSession
+from mcp.client.stdio import get_default_environment
+
+try:
+    from mcp.client.stdio import StdioServerParameters
+except ImportError:  # pragma: no cover - fallback for SDK layout variants
+    import mcp.client.stdio as mcp_stdio
+
+    StdioServerParameters = mcp_stdio.StdioServerParameters
+
+async def main():
+    if len(sys.argv) < 2:
+        print("Usage: uv run python examples/ace_next/mcp_client_demo.py <path_to_ace_mcp_cli>")
+        sys.exit(1)
+        
+    server_path = sys.argv[1]
+    
+    server_params = StdioServerParameters(
+        command=server_path, # usually "ace-mcp" or "uv"
+        args=["run", "ace-mcp"] if "uv" in server_path else [],
+        env={
+            **get_default_environment(),
+            "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY", ""),
+            "GOOGLE_API_KEY": os.environ.get("GOOGLE_API_KEY", ""),
+            "GEMINI_API_KEY": os.environ.get("GEMINI_API_KEY", ""),
+            "MISTRAL_API_KEY": os.environ.get("MISTRAL_API_KEY", ""),
+            "ACE_MCP_DEFAULT_MODEL": os.environ.get("ACE_MCP_DEFAULT_MODEL", ""),
+        },
+    )
+
+    async with stdio_client(server_params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            
+            print("Connected to ACE MCP Server.")
+            
+            # List available tools
+            tools = await session.list_tools()
+            print("\\nAvailable Tools:")
+            for tool in tools.tools:
+                print(f" - {tool.name}")
+                
+            print("\\nTesting ace.ask...")
+            ask_args = {
+                "session_id": "demo-session-1",
+                "question": "What is 2 + 2?"
+            }
+            
+            result = await session.call_tool("ace.ask", ask_args)
+            if result.isError:
+                print(f"Error calling tool: {result.content}")
+            else:
+                for content in result.content:
+                    print(f"Response: {content.text}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,9 +89,14 @@ all = [
     "torch>=2.0.0",
     "accelerate>=0.20.0",
 ]
+mcp = [
+    "mcp>=1.22.0",
+    "pydantic-settings>=2.0.0",
+]
 
 [project.scripts]
 ace-learn = "ace.integrations.claude_code.learner:main"
+ace-mcp = "ace_next.integrations.mcp.server:main"
 
 [project.urls]
 Homepage = "https://kayba.ai"

--- a/specs/002-ace-mcp-server/contracts/tool-schemas.md
+++ b/specs/002-ace-mcp-server/contracts/tool-schemas.md
@@ -1,0 +1,341 @@
+# MCP Tool Schemas: ACE MCP Server
+
+**Feature**: `002-ace-mcp-server`  
+**Date**: 2026-03-02  
+**Status**: Draft Contract (MVP)
+
+This document defines the canonical request/response schemas for MCP tools exposed by ACE.
+
+## Shared Types
+
+### SessionConfig
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "model": { "type": "string", "minLength": 1 },
+    "temperature": { "type": "number", "minimum": 0, "maximum": 2 },
+    "max_tokens": { "type": "integer", "minimum": 1 }
+  },
+  "additionalProperties": false
+}
+```
+
+### ErrorEnvelope
+
+```json
+{
+  "type": "object",
+  "required": ["code", "message"],
+  "properties": {
+    "code": { "type": "string" },
+    "message": { "type": "string" },
+    "details": { "type": ["object", "null"], "additionalProperties": true }
+  },
+  "additionalProperties": false
+}
+```
+
+---
+
+## Tool: `ace.ask`
+
+### Request
+
+```json
+{
+  "type": "object",
+  "required": ["session_id", "question"],
+  "properties": {
+    "session_id": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1, "maxLength": 100000 },
+    "context": { "type": "string", "default": "" },
+    "session_config": { "$ref": "#/definitions/SessionConfig" },
+    "learn": { "type": "boolean", "default": true },
+    "metadata": { "type": "object", "additionalProperties": true }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "SessionConfig": {
+      "type": "object",
+      "properties": {
+        "model": { "type": "string", "minLength": 1 },
+        "temperature": { "type": "number", "minimum": 0, "maximum": 2 },
+        "max_tokens": { "type": "integer", "minimum": 1 }
+      },
+      "additionalProperties": false
+    }
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "type": "object",
+  "required": ["session_id", "answer", "skill_count"],
+  "properties": {
+    "session_id": { "type": "string" },
+    "answer": { "type": "string" },
+    "skill_count": { "type": "integer", "minimum": 0 },
+    "applied_skill_ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+---
+
+## Tool: `ace.learn.sample`
+
+### Request
+
+```json
+{
+  "type": "object",
+  "required": ["session_id", "samples"],
+  "properties": {
+    "session_id": { "type": "string", "minLength": 1 },
+    "samples": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 25,
+      "items": {
+        "type": "object",
+        "required": ["question"],
+        "properties": {
+          "question": { "type": "string", "minLength": 1 },
+          "context": { "type": "string", "default": "" },
+          "ground_truth": { "type": ["string", "null"], "default": null },
+          "metadata": { "type": "object", "additionalProperties": true }
+        },
+        "additionalProperties": false
+      }
+    },
+    "epochs": { "type": "integer", "minimum": 1, "maximum": 20, "default": 1 },
+    "session_config": { "$ref": "#/definitions/SessionConfig" }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "SessionConfig": {
+      "type": "object",
+      "properties": {
+        "model": { "type": "string", "minLength": 1 },
+        "temperature": { "type": "number", "minimum": 0, "maximum": 2 },
+        "max_tokens": { "type": "integer", "minimum": 1 }
+      },
+      "additionalProperties": false
+    }
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "type": "object",
+  "required": ["session_id", "processed", "skill_count_before", "skill_count_after"],
+  "properties": {
+    "session_id": { "type": "string" },
+    "processed": { "type": "integer", "minimum": 0 },
+    "failed": { "type": "integer", "minimum": 0, "default": 0 },
+    "skill_count_before": { "type": "integer", "minimum": 0 },
+    "skill_count_after": { "type": "integer", "minimum": 0 },
+    "new_skill_count": { "type": "integer", "minimum": 0 }
+  },
+  "additionalProperties": false
+}
+```
+
+---
+
+## Tool: `ace.learn.feedback`
+
+### Request
+
+```json
+{
+  "type": "object",
+  "required": ["session_id", "question", "answer", "feedback"],
+  "properties": {
+    "session_id": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "answer": { "type": "string", "minLength": 1 },
+    "feedback": { "type": "string", "minLength": 1 },
+    "context": { "type": "string", "default": "" },
+    "ground_truth": { "type": ["string", "null"], "default": null },
+    "session_config": { "$ref": "#/definitions/SessionConfig" }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "SessionConfig": {
+      "type": "object",
+      "properties": {
+        "model": { "type": "string", "minLength": 1 },
+        "temperature": { "type": "number", "minimum": 0, "maximum": 2 },
+        "max_tokens": { "type": "integer", "minimum": 1 }
+      },
+      "additionalProperties": false
+    }
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "type": "object",
+  "required": ["session_id", "learned", "skill_count_before", "skill_count_after"],
+  "properties": {
+    "session_id": { "type": "string" },
+    "learned": { "type": "boolean" },
+    "skill_count_before": { "type": "integer", "minimum": 0 },
+    "skill_count_after": { "type": "integer", "minimum": 0 },
+    "new_skill_count": { "type": "integer", "minimum": 0 }
+  },
+  "additionalProperties": false
+}
+```
+
+---
+
+## Tool: `ace.skillbook.get`
+
+### Request
+
+```json
+{
+  "type": "object",
+  "required": ["session_id"],
+  "properties": {
+    "session_id": { "type": "string", "minLength": 1 },
+    "limit": { "type": "integer", "minimum": 1, "maximum": 200, "default": 20 },
+    "include_invalid": { "type": "boolean", "default": false }
+  },
+  "additionalProperties": false
+}
+```
+
+### Response
+
+```json
+{
+  "type": "object",
+  "required": ["session_id", "stats", "skills"],
+  "properties": {
+    "session_id": { "type": "string" },
+    "stats": { "type": "object", "additionalProperties": true },
+    "skills": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "content"],
+        "properties": {
+          "id": { "type": "string" },
+          "content": { "type": "string" },
+          "topic": { "type": ["string", "null"] },
+          "helpful": { "type": ["integer", "null"] },
+          "harmful": { "type": ["integer", "null"] },
+          "neutral": { "type": ["integer", "null"] }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+---
+
+## Tool: `ace.skillbook.save`
+
+### Request
+
+```json
+{
+  "type": "object",
+  "required": ["session_id", "path"],
+  "properties": {
+    "session_id": { "type": "string", "minLength": 1 },
+    "path": { "type": "string", "minLength": 1 }
+  },
+  "additionalProperties": false
+}
+```
+
+Path policy: if server config sets `ACE_MCP_SKILLBOOK_ROOT`, `path` MUST resolve inside that directory; otherwise return `ACE_MCP_VALIDATION_ERROR`.
+
+### Response
+
+```json
+{
+  "type": "object",
+  "required": ["session_id", "path", "saved_skill_count"],
+  "properties": {
+    "session_id": { "type": "string" },
+    "path": { "type": "string" },
+    "saved_skill_count": { "type": "integer", "minimum": 0 }
+  },
+  "additionalProperties": false
+}
+```
+
+---
+
+## Tool: `ace.skillbook.load`
+
+### Request
+
+```json
+{
+  "type": "object",
+  "required": ["session_id", "path"],
+  "properties": {
+    "session_id": { "type": "string", "minLength": 1 },
+    "path": { "type": "string", "minLength": 1 },
+    "replace": { "type": "boolean", "default": true }
+  },
+  "additionalProperties": false
+}
+```
+
+Path policy: if server config sets `ACE_MCP_SKILLBOOK_ROOT`, `path` MUST resolve inside that directory; otherwise return `ACE_MCP_VALIDATION_ERROR`.
+
+### Response
+
+```json
+{
+  "type": "object",
+  "required": ["session_id", "path", "skill_count"],
+  "properties": {
+    "session_id": { "type": "string" },
+    "path": { "type": "string" },
+    "skill_count": { "type": "integer", "minimum": 0 }
+  },
+  "additionalProperties": false
+}
+```
+
+---
+
+## Safe Mode Policy Matrix
+
+| Tool | Allowed in `safe_mode=true` |
+|------|-----------------------------|
+| `ace.ask` | ✅ |
+| `ace.skillbook.get` | ✅ |
+| `ace.learn.sample` | ❌ |
+| `ace.learn.feedback` | ❌ |
+| `ace.skillbook.save` | ❌ |
+| `ace.skillbook.load` | ❌ |
+
+Blocked calls must return `ACE_MCP_FORBIDDEN_IN_SAFE_MODE`.

--- a/specs/002-ace-mcp-server/spec.md
+++ b/specs/002-ace-mcp-server/spec.md
@@ -1,0 +1,233 @@
+# Feature Specification: ACE MCP Server (Optional)
+
+**Feature Branch**: `002-ace-mcp-server`  
+**Created**: 2026-03-02  
+**Status**: Draft  
+**Input**: User description: "extend ACE to also work as an MCP server (optional but powerful)"
+
+## Summary
+
+Add an optional MCP server mode for ACE using the `ace_next` architecture. The server exposes ACE capabilities as MCP tools so external MCP clients (IDEs, copilots, orchestrators) can call ACE for inference and learning.
+
+The feature is **opt-in** via optional dependency extras and a dedicated CLI entrypoint. Existing ACE APIs and integrations remain unchanged when MCP is not enabled.
+
+## Scope
+
+### In Scope (MVP)
+
+- MCP server over stdio transport.
+- Tool endpoints for ask/learn/skillbook operations.
+- Per-session ACE runner lifecycle with in-memory state.
+- Input/output validation with Pydantic models.
+- Structured error mapping to MCP tool errors.
+- Unit + integration tests for handler behavior and transport startup.
+- Docs and runnable example client.
+
+### Out of Scope (Post-MVP)
+
+- HTTP/SSE MCP transport.
+- Distributed or persistent multi-process session stores.
+- AuthN/AuthZ and multi-tenant isolation beyond local process boundaries.
+- Rich observability dashboards (basic logs only in MVP).
+
+## Design Constraints
+
+- Implement in `ace_next` integration layer, not in `pipeline/` or `ace_next/core/` for MVP.
+- Preserve backward compatibility: no breaking changes to existing runners.
+- Keep MCP dependency optional (no mandatory install-time dependency).
+- Use existing ACE runner constructors (`from_model`, `from_roles`) and skillbook persistence APIs.
+
+## User Scenarios & Testing
+
+### User Story 1 — Ask Through MCP (P1)
+
+A client calls `ace.ask` through MCP and gets an answer from a session-scoped ACE instance.
+
+**Independent test**: start server, call `ace.ask`, assert valid answer payload and session state initialization.
+
+### User Story 2 — Learn Through MCP (P1)
+
+A client calls `ace.learn.sample` and `ace.learn.feedback`; ACE updates the skillbook for that session.
+
+**Independent test**: call learning tools, then `ace.skillbook.get`, assert strategy count changed.
+
+### User Story 3 — Persist/Restore Skillbook (P2)
+
+A client saves skillbook to disk and later reloads it into the same/new session.
+
+**Independent test**: `save` then `load` and assert stable strategy IDs/count.
+
+### User Story 4 — Safe Optionality (P1)
+
+Projects without MCP extras continue functioning exactly as before.
+
+**Independent test**: import and use non-MCP modules without MCP installed.
+
+## Functional Requirements
+
+- **FR-001**: System MUST provide a CLI entrypoint to run ACE as an MCP server over stdio.
+- **FR-002**: System MUST expose MCP tools: `ace.ask`, `ace.learn.sample`, `ace.learn.feedback`, `ace.skillbook.get`, `ace.skillbook.save`, `ace.skillbook.load`.
+- **FR-003**: System MUST validate every tool request and response via typed schemas.
+- **FR-004**: System MUST isolate state by `session_id`.
+- **FR-005**: System MUST lazily initialize session runners with model/provider config.
+- **FR-006**: System MUST support disabling mutating tools (`save/load` and learn tools) in safe mode.
+- **FR-007**: System MUST map internal exceptions to stable MCP error codes/messages.
+- **FR-008**: System MUST cap request sizes (max samples per call, max payload size) to prevent runaway execution.
+- **FR-009**: System MUST remain fully optional via `mcp` extra dependency.
+- **FR-010**: System MUST include integration tests that exercise server startup and at least one successful call per tool.
+
+## Non-Functional Requirements
+
+- **NFR-001**: Tool roundtrip latency for `ace.ask` should be < 2s p50 excluding model latency.
+- **NFR-002**: Session operations must be thread-safe within a process.
+- **NFR-003**: Server startup failures must emit actionable install/config error text.
+- **NFR-004**: Existing test suite behavior remains unchanged when MCP extras are absent.
+
+## Tool Contract Source of Truth
+
+Canonical tool schemas are defined in: `specs/002-ace-mcp-server/contracts/tool-schemas.md`.
+
+## Exact Module Tree (Implementation)
+
+```text
+ace_next/
+  integrations/
+    mcp/
+      __init__.py
+      server.py                 # create_server(), main(), startup wiring
+      registry.py               # session registry + lifecycle (TTL, lazy init)
+      config.py                 # MCPServerConfig, limits, safe-mode flags
+      errors.py                 # domain errors + MCP error mapping
+      models.py                 # Pydantic request/response schemas
+      handlers.py               # tool handler implementations
+      adapters.py               # maps handlers <-> MCP SDK tool registration
+
+tests/
+  test_ace_next_mcp_models.py      # schema validation and serialization
+  test_ace_next_mcp_registry.py    # session lifecycle and locking
+  test_ace_next_mcp_handlers.py    # tool behavior with mocked runner
+  test_ace_next_mcp_server.py      # server startup + tool registration smoke
+
+docs/
+  integrations/
+    mcp.md                      # install, run, tool catalog, examples
+
+examples/
+  ace_next/
+    mcp_client_demo.py          # minimal MCP client invoking ace.ask
+```
+
+## Package and CLI Changes
+
+- `pyproject.toml`
+  - Add optional dependency group:
+    - `mcp = ["mcp>=<pinned_version>"]` (or official Python MCP SDK package used by maintainers)
+  - Add script entrypoint:
+    - `ace-mcp = "ace_next.integrations.mcp.server:main"`
+
+## Runtime Architecture
+
+1. MCP server starts and registers tool definitions from `models.py`.
+2. Incoming request is validated into typed request model.
+3. `registry.py` returns/create session runner (`ACELiteLLM` by default).
+4. `handlers.py` executes operation against runner.
+5. Response serialized to typed output model.
+6. Exceptions mapped through `errors.py` into stable MCP error responses.
+
+## Session Model
+
+- Key: `session_id: str`.
+- Value: session object containing runner, creation time, last access time, lock.
+- Concurrency: per-session lock around mutating operations.
+- Expiry: configurable TTL cleanup (lazy sweep on access in MVP).
+
+## Configuration Model
+
+`MCPServerConfig` fields (MVP):
+
+- `default_model: str = "gpt-4o-mini"`
+- `safe_mode: bool = false`
+- `max_samples_per_call: int = 25`
+- `max_prompt_chars: int = 100_000`
+- `session_ttl_seconds: int = 3600`
+- `allow_save_load: bool = true`
+- `skillbook_root: str | None = null`
+- `log_level: str = "INFO"`
+
+Environment variable mapping (MVP):
+
+- `ACE_MCP_DEFAULT_MODEL`
+- `ACE_MCP_SAFE_MODE`
+- `ACE_MCP_MAX_SAMPLES_PER_CALL`
+- `ACE_MCP_MAX_PROMPT_CHARS`
+- `ACE_MCP_SESSION_TTL_SECONDS`
+- `ACE_MCP_ALLOW_SAVE_LOAD`
+- `ACE_MCP_SKILLBOOK_ROOT`
+
+## Error Taxonomy
+
+- `ACE_MCP_VALIDATION_ERROR`
+- `ACE_MCP_SESSION_NOT_FOUND`
+- `ACE_MCP_FORBIDDEN_IN_SAFE_MODE`
+- `ACE_MCP_PROVIDER_ERROR`
+- `ACE_MCP_TIMEOUT`
+- `ACE_MCP_INTERNAL_ERROR`
+
+Each error must include:
+
+- `code` (stable string)
+- `message` (human-readable)
+- `details` (optional structured dict)
+
+## Security & Safety
+
+- Safe mode blocks mutating operations by policy.
+- Path validation for save/load (reject paths outside `ACE_MCP_SKILLBOOK_ROOT` when set).
+- Request size limits enforced before runner call.
+- No secret values logged in payload dumps.
+
+## Testing Plan
+
+### Unit
+
+- `models.py`: required fields, type coercion, limits.
+- `registry.py`: session create/get/delete, TTL expiry, lock semantics.
+- `handlers.py`: tool success paths + mapped failures.
+
+### Integration
+
+- Boot server with MCP SDK test harness.
+- Validate tool registration and one successful invocation per tool.
+- Validate safe mode blocks expected tools.
+
+### Regression
+
+- Run existing `ace_next` tests ensuring no MCP dependency required unless explicitly installed.
+
+## Delivery Plan (PR Sequence)
+
+1. **PR-1**: skeleton package + config + models + tests.
+2. **PR-2**: session registry + handlers for `ace.ask` and `ace.skillbook.get`.
+3. **PR-3**: learning + save/load handlers, error mapping, limits.
+4. **PR-4**: server bootstrap + CLI entrypoint + integration tests.
+5. **PR-5**: docs + example client + changelog entry.
+
+## Acceptance Criteria
+
+- All FR/NFR satisfied.
+- Tool schemas match contract doc exactly.
+- `ace-mcp` starts successfully and serves all MVP tools.
+- Existing non-MCP workflows are unaffected.
+
+## Ready for Merge Checklist
+
+- [x] Module tree implemented under `ace_next/integrations/mcp/`
+- [x] Tool schemas implemented and contract-aligned (`ace.ask`, `ace.learn.sample`, `ace.learn.feedback`, `ace.skillbook.get/save/load`)
+- [x] Optional dependency and CLI entrypoint wired (`mcp` extra, `ace-mcp`)
+- [x] Safe mode policy enforced for mutating tools
+- [x] Request-size limits enforced (`max_prompt_chars`, `max_samples_per_call`)
+- [x] Optional root-bound path validation enforced for save/load (`ACE_MCP_SKILLBOOK_ROOT`)
+- [x] MCP-focused tests passing (`test_ace_next_mcp_models/registry/handlers/server`)
+- [x] Unit regression run and passing after MCP changes
+- [x] Docs + example client updated (`docs/integrations/mcp.md`, `examples/ace_next/mcp_client_demo.py`)
+- [x] Changelog updated for this feature

--- a/tests/test_ace_next_mcp_handlers.py
+++ b/tests/test_ace_next_mcp_handlers.py
@@ -1,0 +1,139 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from ace_next.integrations.mcp.config import MCPServerConfig
+from ace_next.integrations.mcp.registry import SessionRegistry
+from ace_next.integrations.mcp.handlers import MCPHandlers
+from ace_next.integrations.mcp.models import (
+    AskRequest, LearnSampleRequest, LearnFeedbackRequest,
+    SkillbookGetRequest, SkillbookSaveRequest, SkillbookLoadRequest,
+    SampleItem
+)
+from ace_next.integrations.mcp.errors import ForbiddenInSafeModeError, ValidationError
+
+@pytest.fixture
+def config():
+    return MCPServerConfig(safe_mode=False)
+
+@pytest.fixture
+def registry(config):
+    return SessionRegistry(config)
+
+@pytest.fixture
+def handlers(registry, config):
+    return MCPHandlers(registry, config)
+
+@pytest.mark.asyncio
+async def test_handle_ask(handlers):
+    with patch("ace_next.integrations.mcp.registry.ACELiteLLM") as mock_runner_cls:
+        runner = MagicMock()
+        runner.ask.return_value = "answer"
+        runner.skillbook.skills.return_value = [1, 2, 3]
+        mock_runner_cls.from_model.return_value = runner
+        
+        req = AskRequest(session_id="s1", question="q")
+        resp = await handlers.handle_ask(req)
+        
+        assert resp.answer == "answer"
+        assert resp.skill_count == 3
+        runner.ask.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_handle_skillbook_get(handlers, registry):
+    with patch("ace_next.integrations.mcp.registry.ACELiteLLM") as mock_runner_cls:
+        runner = MagicMock()
+        mock_skill = MagicMock()
+        mock_skill.id = "k1"
+        mock_skill.content = "cont"
+        mock_skill.section = "test"
+        mock_skill.helpful = 1
+        mock_skill.harmful = 0
+        mock_skill.neutral = 0
+        runner.skillbook.skills.return_value = [mock_skill]
+        runner.skillbook.stats.return_value = {"skills": 1}
+        mock_runner_cls.from_model.return_value = runner
+        
+        await registry.get_or_create("s1")
+        req = SkillbookGetRequest(session_id="s1")
+        resp = await handlers.handle_skillbook_get(req)
+        
+        assert len(resp.skills) == 1
+        assert resp.skills[0].id == "k1"
+        assert resp.stats["skills"] == 1
+
+@pytest.mark.asyncio
+async def test_handle_learn_sample_safe_mode(handlers):
+    handlers.config.safe_mode = True
+    req = LearnSampleRequest(session_id="s1", samples=[SampleItem(question="q")])
+    with pytest.raises(ForbiddenInSafeModeError):
+        await handlers.handle_learn_sample(req)
+
+@pytest.mark.asyncio
+async def test_handle_save_load_safe_mode(handlers, registry):
+    handlers.config.safe_mode = True
+    with patch("ace_next.integrations.mcp.registry.ACELiteLLM"):
+        await registry.get_or_create("s1")
+        req1 = SkillbookSaveRequest(session_id="s1", path="/tmp/some")
+        with pytest.raises(ForbiddenInSafeModeError):
+            await handlers.handle_skillbook_save(req1)
+            
+        req2 = SkillbookLoadRequest(session_id="s1", path="/tmp/some")
+        with pytest.raises(ForbiddenInSafeModeError):
+            await handlers.handle_skillbook_load(req2)
+
+
+@pytest.mark.asyncio
+async def test_handle_ask_enforces_prompt_limit(handlers):
+    handlers.config.max_prompt_chars = 10
+    req = AskRequest(session_id="s1", question="12345678901")
+    with pytest.raises(ValidationError):
+        await handlers.handle_ask(req)
+
+
+@pytest.mark.asyncio
+async def test_handle_learn_sample_enforces_runtime_sample_limit(handlers):
+    handlers.config.max_samples_per_call = 1
+    req = LearnSampleRequest(
+        session_id="s1",
+        samples=[SampleItem(question="q1"), SampleItem(question="q2")],
+    )
+    with pytest.raises(ValidationError):
+        await handlers.handle_learn_sample(req)
+
+
+@pytest.mark.asyncio
+async def test_handle_learn_feedback_uses_trace_learning(handlers):
+    with patch("ace_next.integrations.mcp.registry.ACELiteLLM") as mock_runner_cls:
+        runner = MagicMock()
+        runner.skillbook.skills.side_effect = [["a"], ["a", "b"]]
+        runner.learn_from_traces.return_value = []
+        mock_runner_cls.from_model.return_value = runner
+
+        req = LearnFeedbackRequest(
+            session_id="s1",
+            question="q",
+            answer="a",
+            feedback="good",
+        )
+        resp = await handlers.handle_learn_feedback(req)
+
+        assert resp.learned is True
+        assert resp.new_skill_count == 1
+        runner.learn_from_traces.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_skillbook_save_rejects_path_outside_root(handlers, registry):
+    handlers.config.skillbook_root = "/tmp/ace-root"
+    with patch("ace_next.integrations.mcp.registry.ACELiteLLM"):
+        await registry.get_or_create("s1")
+        req = SkillbookSaveRequest(session_id="s1", path="/tmp/not-allowed/file.json")
+        with pytest.raises(ValidationError):
+            await handlers.handle_skillbook_save(req)
+
+
+@pytest.mark.asyncio
+async def test_handle_skillbook_load_rejects_path_outside_root(handlers):
+    handlers.config.skillbook_root = "/tmp/ace-root"
+    req = SkillbookLoadRequest(session_id="s1", path="/tmp/not-allowed/file.json")
+    with pytest.raises(ValidationError):
+        await handlers.handle_skillbook_load(req)

--- a/tests/test_ace_next_mcp_models.py
+++ b/tests/test_ace_next_mcp_models.py
@@ -1,0 +1,65 @@
+import pytest
+from pydantic import ValidationError
+from ace_next.integrations.mcp.models import (
+    AskRequest, AskResponse,
+    LearnSampleRequest, LearnSampleResponse,
+    LearnFeedbackRequest, LearnFeedbackResponse,
+    SkillbookGetRequest, SkillbookGetResponse,
+    SkillbookSaveRequest, SkillbookSaveResponse,
+    SkillbookLoadRequest, SkillbookLoadResponse,
+    SessionConfig, SampleItem, SkillItem, ErrorEnvelope
+)
+
+def test_session_config_validation():
+    # Valid with all fields
+    config = SessionConfig(model="gpt-4o", temperature=0.7, max_tokens=100)
+    assert config.model == "gpt-4o"
+
+    # Valid without model (optional per contract)
+    config2 = SessionConfig(temperature=0.5)
+    assert config2.model is None
+    
+    # Invalid: empty string for model
+    with pytest.raises(ValidationError):
+        SessionConfig(model="")
+        
+    # Invalid temp
+    with pytest.raises(ValidationError):
+        SessionConfig(model="gpt-4o", temperature=2.5)
+
+def test_ask_request_validation():
+    # Valid
+    req = AskRequest(session_id="s1", question="hello")
+    assert req.learn is True
+    assert req.context == ""
+    
+    # Max length question
+    with pytest.raises(ValidationError):
+        AskRequest(session_id="s1", question="a" * 100001)
+
+def test_learn_sample_request_limits():
+    # Min items
+    with pytest.raises(ValidationError):
+        LearnSampleRequest(session_id="s1", samples=[])
+        
+    # Max items
+    samples = [{"question": f"q{i}"} for i in range(26)]
+    with pytest.raises(ValidationError):
+        LearnSampleRequest(session_id="s1", samples=samples)
+
+def test_skillbook_get_limits():
+    # Valid
+    req = SkillbookGetRequest(session_id="s", limit=50)
+    assert req.limit == 50
+    
+    # Max limit
+    with pytest.raises(ValidationError):
+        SkillbookGetRequest(session_id="s", limit=201)
+
+def test_error_envelope():
+    env = ErrorEnvelope(code="ERR1", message="Error message")
+    assert env.code == "ERR1"
+    
+    # Extra fields forbidden
+    with pytest.raises(ValidationError):
+        ErrorEnvelope(code="ERR1", message="m", extra="not allowed")

--- a/tests/test_ace_next_mcp_registry.py
+++ b/tests/test_ace_next_mcp_registry.py
@@ -1,0 +1,65 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock, patch
+from ace_next.integrations.mcp.config import MCPServerConfig
+from ace_next.integrations.mcp.registry import SessionRegistry
+from ace_next.integrations.mcp.errors import SessionNotFoundError
+
+@pytest.fixture
+def config():
+    return MCPServerConfig(session_ttl_seconds=1)
+
+@pytest.fixture
+def registry(config):
+    return SessionRegistry(config)
+
+@pytest.mark.asyncio
+async def test_get_or_create(registry):
+    with patch("ace_next.integrations.mcp.registry.ACELiteLLM") as mock_runner_cls:
+        mock_runner_cls.from_model.return_value = MagicMock()
+        
+        # Create
+        s1 = await registry.get_or_create("s1")
+        assert s1.session_id == "s1"
+        assert s1.runner is not None
+        mock_runner_cls.from_model.assert_called_once_with("gpt-4o-mini")
+        
+        # Get existing
+        s1_again = await registry.get_or_create("s1")
+        assert s1 is s1_again
+        assert mock_runner_cls.from_model.call_count == 1
+
+@pytest.mark.asyncio
+async def test_get_existing(registry):
+    with patch("ace_next.integrations.mcp.registry.ACELiteLLM"):
+        s1 = await registry.get_or_create("s1")
+        s1_get = await registry.get("s1")
+        assert s1 is s1_get
+
+@pytest.mark.asyncio
+async def test_get_not_found(registry):
+    with pytest.raises(SessionNotFoundError):
+        await registry.get("nonexistent")
+
+@pytest.mark.asyncio
+async def test_sweep_expired(registry):
+    with patch("ace_next.integrations.mcp.registry.ACELiteLLM"):
+        s1 = await registry.get_or_create("s1")
+        
+        # Should not expire immediately
+        await registry.get("s1")
+        
+        # Wait for TTL to pass (config TTL is 1 sec)
+        await asyncio.sleep(1.1)
+        
+        with pytest.raises(SessionNotFoundError):
+            await registry.get("s1")
+
+@pytest.mark.asyncio
+async def test_delete(registry):
+    with patch("ace_next.integrations.mcp.registry.ACELiteLLM"):
+        await registry.get_or_create("s1")
+        await registry.delete("s1")
+        
+        with pytest.raises(SessionNotFoundError):
+            await registry.get("s1")

--- a/tests/test_ace_next_mcp_server.py
+++ b/tests/test_ace_next_mcp_server.py
@@ -1,0 +1,33 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from ace_next.integrations.mcp.server import create_server
+from ace_next.integrations.mcp.adapters import register_tools
+from mcp.server import Server
+from mcp.types import ListToolsRequest
+
+EXPECTED_TOOL_NAMES = {
+    "ace.ask",
+    "ace.learn.sample",
+    "ace.learn.feedback",
+    "ace.skillbook.get",
+    "ace.skillbook.save",
+    "ace.skillbook.load",
+}
+
+def test_create_server():
+    server = create_server()
+    assert isinstance(server, Server)
+    assert server.name == "ace-mcp-server"
+
+@pytest.mark.asyncio
+async def test_tool_registration():
+    """All 6 MVP tools must be registered (FR-002)."""
+    server = create_server()
+
+    handler = server.request_handlers.get(ListToolsRequest)
+    assert handler is not None, "tools/list handler not registered"
+
+    result = await handler(MagicMock())
+    registered_names = {t.name for t in result.root.tools}
+    assert registered_names == EXPECTED_TOOL_NAMES
+

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "ace-framework"
-version = "0.8.3"
+version = "0.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },
@@ -70,6 +70,10 @@ langchain = [
     { name = "langchain-litellm" },
     { name = "langchain-openai" },
     { name = "langgraph" },
+]
+mcp = [
+    { name = "mcp" },
+    { name = "pydantic-settings" },
 ]
 observability = [
     { name = "opik" },
@@ -121,11 +125,13 @@ requires-dist = [
     { name = "langgraph", marker = "extra == 'all'", specifier = ">=0.2.0" },
     { name = "langgraph", marker = "extra == 'langchain'", specifier = ">=0.2.0" },
     { name = "litellm", specifier = ">=1.78.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.22.0" },
     { name = "numpy", marker = "extra == 'all'", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'deduplication'", specifier = ">=1.24.0" },
     { name = "opik", marker = "extra == 'all'", specifier = ">=1.8.0" },
     { name = "opik", marker = "extra == 'observability'", specifier = ">=1.8.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pydantic-settings", marker = "extra == 'mcp'", specifier = ">=2.0.0" },
     { name = "python-dotenv", marker = "extra == 'all'", specifier = ">=1.0.0" },
     { name = "python-dotenv", marker = "extra == 'claude-code'", specifier = ">=1.0.0" },
     { name = "python-toon", specifier = ">=0.1.0" },
@@ -138,7 +144,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'all'", specifier = ">=4.30.0" },
     { name = "transformers", marker = "extra == 'transformers'", specifier = ">=4.30.0" },
 ]
-provides-extras = ["claude-code", "instructor", "deduplication", "browser-use", "observability", "langchain", "transformers", "all"]
+provides-extras = ["claude-code", "instructor", "deduplication", "browser-use", "observability", "langchain", "transformers", "all", "mcp"]
 
 [package.metadata.requires-dev]
 demos = [


### PR DESCRIPTION
# feat(mcp): optional ACE MCP server integration (feature 002)

## Summary
This PR adds optional MCP server support to ACE via `ace_next`, enabling external MCP clients to use ACE as a reusable tool service for inference and learning. The implementation follows feature 002 spec and keeps MCP fully optional for non-MCP users.

- [Spec](https://github.com/omar-A-hassan/agentic-context-engine/blob/feature/omar/mcp-server-002/specs/002-ace-mcp-server/spec.md)
- [Contract](https://github.com/omar-A-hassan/agentic-context-engine/blob/feature/omar/mcp-server-002/specs/002-ace-mcp-server/contracts/tool-schemas.md)

## What changed
- Added MCP integration package under `ace_next/integrations/mcp`:
  - server startup over stdio
  - session registry keyed by `session_id` with TTL and per-session locks
  - typed request/response schemas
  - tool handlers and MCP adapters
  - stable MCP error taxonomy/mapping
- Added six tools:
  - `ace.ask`
  - `ace.learn.sample`
  - `ace.learn.feedback`
  - `ace.skillbook.get`
  - `ace.skillbook.save`
  - `ace.skillbook.load`
- Added packaging updates:
  - optional extra: `mcp`
  - CLI entrypoint: `ace-mcp`
- Added safety controls:
  - safe mode blocks mutating tools
  - `max_prompt_chars` and `max_samples_per_call` runtime guards
  - optional `ACE_MCP_SKILLBOOK_ROOT` path enforcement for save/load
- Added docs and examples:
  - `mcp.md`
  - `mcp_client_demo.py`
- Updated specs/contracts/changelog:
  - `spec.md`
  - `tool-schemas.md`
  - `CHANGELOG.md`

## Validation performed
- `uv sync --extra mcp`
- `uv run pytest tests/test_ace_next_mcp_models.py tests/test_ace_next_mcp_registry.py tests/test_ace_next_mcp_handlers.py tests/test_ace_next_mcp_server.py`
- `uv run pytest -m unit`

## Results
- MCP suite: passing
- Unit suite: passing (`754 passed`)

## Notes
- NFR latency target (`<2s p50` excluding model latency) is not benchmarked in CI.
- `applied_skill_ids` currently returns empty list (contract-compliant default).