### PR TITLE
feat(ace_next): expose pipeline as first-class public API

### DIFF
--- a/ace_next/__init__.py
+++ b/ace_next/__init__.py
@@ -1,5 +1,11 @@
 """ACE next — pipeline-based rewrite of the ACE framework."""
 
+# Pipeline engine (re-exported from pipeline/)
+from pipeline import Branch, MergeStrategy, Pipeline, SampleResult, StepProtocol
+
+# ACE context
+from .core import ACEStepContext, SkillbookView
+
 # Core types
 from .core import (
     EnvironmentResult,
@@ -20,18 +26,47 @@ from .providers import (
     LiteLLMClient,
     wrap_with_instructor,
 )
+
+# Runners
 from .runners import (
     ACE,
     ACELiteLLM,
+    ACERunner,
     BrowserUse,
     ClaudeCode,
     LangChain,
     TraceAnalyser,
 )
 from .rr import RRConfig, RRStep
+
+# Steps
+from .steps import (
+    AgentStep,
+    ApplyStep,
+    CheckpointStep,
+    DeduplicateStep,
+    EvaluateStep,
+    ExportSkillbookMarkdownStep,
+    LoadTracesStep,
+    ObservabilityStep,
+    PersistStep,
+    ReflectStep,
+    TagStep,
+    UpdateStep,
+    learning_tail,
+)
 from .steps.opik import OPIK_AVAILABLE, OpikStep, register_opik_litellm_callback
 
 __all__ = [
+    # Pipeline composition
+    "Pipeline",
+    "Branch",
+    "MergeStrategy",
+    "StepProtocol",
+    "SampleResult",
+    # ACE context
+    "ACEStepContext",
+    "SkillbookView",
     # Core data types
     "Skill",
     "Skillbook",
@@ -53,10 +88,25 @@ __all__ = [
     # Runners
     "ACE",
     "ACELiteLLM",
+    "ACERunner",
     "BrowserUse",
     "ClaudeCode",
     "LangChain",
     "TraceAnalyser",
+    # Steps
+    "AgentStep",
+    "EvaluateStep",
+    "ReflectStep",
+    "TagStep",
+    "UpdateStep",
+    "ApplyStep",
+    "DeduplicateStep",
+    "CheckpointStep",
+    "LoadTracesStep",
+    "ExportSkillbookMarkdownStep",
+    "ObservabilityStep",
+    "PersistStep",
+    "learning_tail",
     # Recursive Reflector
     "RRStep",
     "RRConfig",

--- a/ace_next/runners/ace.py
+++ b/ace_next/runners/ace.py
@@ -36,6 +36,62 @@ class ACE(ACERunner):
     """
 
     @classmethod
+    def build_steps(
+        cls,
+        *,
+        agent: AgentLike,
+        reflector: ReflectorLike,
+        skill_manager: SkillManagerLike,
+        environment: TaskEnvironment | None = None,
+        skillbook: Skillbook | None = None,
+        dedup_manager: DeduplicationManagerLike | None = None,
+        dedup_interval: int = 10,
+        checkpoint_dir: str | Path | None = None,
+        checkpoint_interval: int = 10,
+        extra_steps: list[StepProtocol] | None = None,
+    ) -> list[StepProtocol]:
+        """Return the steps that ``from_roles()`` would compose.
+
+        Use this to inspect, modify, or extend the pipeline before
+        constructing it yourself::
+
+            steps = ACE.build_steps(agent=agent, reflector=reflector, ...)
+            steps.insert(2, MyCustomStep())
+            pipe = Pipeline(steps)
+            runner = ACERunner(pipeline=pipe, skillbook=skillbook)
+
+        Args:
+            agent: Agent role for producing answers.
+            reflector: Reflector role for analysing execution.
+            skill_manager: SkillManager role for update operations.
+            environment: Optional task environment for evaluation feedback.
+            skillbook: Starting skillbook.  Creates an empty one if ``None``.
+            dedup_manager: Optional deduplication manager.
+            dedup_interval: Samples between deduplication runs.
+            checkpoint_dir: Directory for checkpoint files.
+            checkpoint_interval: Samples between checkpoint saves.
+            extra_steps: Additional steps appended after the learning
+                tail (e.g. ``OpikStep``).
+        """
+        skillbook = skillbook or Skillbook()
+        steps: list[StepProtocol] = [
+            AgentStep(agent),
+            EvaluateStep(environment),
+            *learning_tail(
+                reflector,
+                skill_manager,
+                skillbook,
+                dedup_manager=dedup_manager,
+                dedup_interval=dedup_interval,
+                checkpoint_dir=checkpoint_dir,
+                checkpoint_interval=checkpoint_interval,
+            ),
+        ]
+        if extra_steps:
+            steps.extend(extra_steps)
+        return steps
+
+    @classmethod
     def from_roles(
         cls,
         *,
@@ -69,21 +125,18 @@ class ACE(ACERunner):
                 tail (e.g. ``OpikStep``).
         """
         skillbook = skillbook or Skillbook()
-        steps = [
-            AgentStep(agent),
-            EvaluateStep(environment),
-            *learning_tail(
-                reflector,
-                skill_manager,
-                skillbook,
-                dedup_manager=dedup_manager,
-                dedup_interval=dedup_interval,
-                checkpoint_dir=checkpoint_dir,
-                checkpoint_interval=checkpoint_interval,
-            ),
-        ]
-        if extra_steps:
-            steps.extend(extra_steps)
+        steps = cls.build_steps(
+            agent=agent,
+            reflector=reflector,
+            skill_manager=skill_manager,
+            environment=environment,
+            skillbook=skillbook,
+            dedup_manager=dedup_manager,
+            dedup_interval=dedup_interval,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_interval=checkpoint_interval,
+            extra_steps=extra_steps,
+        )
         return cls(pipeline=Pipeline(steps), skillbook=skillbook)
 
     def run(

--- a/ace_next/runners/base.py
+++ b/ace_next/runners/base.py
@@ -26,6 +26,19 @@ class ACERunner:
 
     - ``run()`` — public API with a subclass-specific signature.
     - ``_build_context()`` — maps a single input item to ``ACEStepContext``.
+
+    You can also construct an ``ACERunner`` directly with a hand-composed
+    pipeline::
+
+        from ace_next import Pipeline, ACERunner, AgentStep, learning_tail
+
+        pipe = Pipeline([AgentStep(agent), *learning_tail(reflector, sm, sb)])
+        runner = ACERunner(pipeline=pipe, skillbook=sb)
+
+    Attributes:
+        pipeline: The composed ``Pipeline`` instance.  Accessible for
+            inspection after construction.
+        skillbook: The ``Skillbook`` this runner operates on.
     """
 
     def __init__(

--- a/ace_next/runners/browser_use.py
+++ b/ace_next/runners/browser_use.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from pipeline import Pipeline
-from pipeline.protocol import SampleResult
+from pipeline.protocol import SampleResult, StepProtocol
 
 from ..core.context import ACEStepContext, SkillbookView
 from ..core.skillbook import Skillbook
@@ -47,6 +47,75 @@ class BrowserUse(ACERunner):
     """
 
     @classmethod
+    def build_steps(
+        cls,
+        *,
+        browser_llm: Any,
+        reflector: ReflectorLike,
+        skill_manager: SkillManagerLike,
+        skillbook: Skillbook | None = None,
+        skillbook_path: Optional[str] = None,
+        browser: Any = None,
+        agent_kwargs: dict[str, Any] | None = None,
+        dedup_config: Optional[DeduplicationConfig] = None,
+        dedup_manager: DeduplicationManagerLike | None = None,
+        dedup_interval: int = 10,
+        checkpoint_dir: str | Path | None = None,
+        checkpoint_interval: int = 10,
+    ) -> list[StepProtocol]:
+        """Return the steps that ``from_roles()`` would compose.
+
+        Use this to inspect, modify, or extend the pipeline before
+        constructing it yourself::
+
+            steps = BrowserUse.build_steps(browser_llm=llm, reflector=r, ...)
+            steps.insert(2, MyCustomStep())
+            pipe = Pipeline(steps)
+            runner = ACERunner(pipeline=pipe, skillbook=skillbook)
+
+        Args:
+            browser_llm: LLM for browser-use execution.
+            reflector: Reflector role for analysing execution traces.
+            skill_manager: SkillManager role for update operations.
+            skillbook: Starting skillbook.  Creates an empty one if ``None``.
+            skillbook_path: Path to load skillbook from.
+            browser: Optional browser-use Browser instance.
+            agent_kwargs: Extra kwargs forwarded to browser-use Agent.
+            dedup_config: Deduplication configuration.
+            dedup_manager: Optional pre-built deduplication manager.
+            dedup_interval: Samples between deduplication runs.
+            checkpoint_dir: Directory for checkpoint files.
+            checkpoint_interval: Samples between checkpoint saves.
+        """
+        # Resolve skillbook
+        if skillbook_path:
+            skillbook = Skillbook.load_from_file(skillbook_path)
+        elif skillbook is None:
+            skillbook = Skillbook()
+
+        # Resolve dedup manager
+        dm = dedup_manager
+        if dm is None and dedup_config is not None:
+            from ..deduplication import DeduplicationManager
+
+            dm = DeduplicationManager(dedup_config)
+
+        steps: list[StepProtocol] = [
+            BrowserExecuteStep(browser_llm, browser=browser, **(agent_kwargs or {})),
+            BrowserToTrace(),
+            *learning_tail(
+                reflector,
+                skill_manager,
+                skillbook,
+                dedup_manager=dm,
+                dedup_interval=dedup_interval,
+                checkpoint_dir=checkpoint_dir,
+                checkpoint_interval=checkpoint_interval,
+            ),
+        ]
+        return steps
+
+    @classmethod
     def from_roles(
         cls,
         *,
@@ -79,32 +148,25 @@ class BrowserUse(ACERunner):
             checkpoint_dir: Directory for checkpoint files.
             checkpoint_interval: Samples between checkpoint saves.
         """
-        # Resolve skillbook
+        # Resolve skillbook (must match build_steps resolution)
         if skillbook_path:
             skillbook = Skillbook.load_from_file(skillbook_path)
         elif skillbook is None:
             skillbook = Skillbook()
 
-        # Resolve dedup manager
-        dm = dedup_manager
-        if dm is None and dedup_config is not None:
-            from ..deduplication import DeduplicationManager
-
-            dm = DeduplicationManager(dedup_config)
-
-        steps = [
-            BrowserExecuteStep(browser_llm, browser=browser, **(agent_kwargs or {})),
-            BrowserToTrace(),
-            *learning_tail(
-                reflector,
-                skill_manager,
-                skillbook,
-                dedup_manager=dm,
-                dedup_interval=dedup_interval,
-                checkpoint_dir=checkpoint_dir,
-                checkpoint_interval=checkpoint_interval,
-            ),
-        ]
+        steps = cls.build_steps(
+            browser_llm=browser_llm,
+            reflector=reflector,
+            skill_manager=skill_manager,
+            skillbook=skillbook,
+            browser=browser,
+            agent_kwargs=agent_kwargs,
+            dedup_config=dedup_config,
+            dedup_manager=dedup_manager,
+            dedup_interval=dedup_interval,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_interval=checkpoint_interval,
+        )
         return cls(pipeline=Pipeline(steps), skillbook=skillbook)
 
     @classmethod

--- a/ace_next/runners/claude_code.py
+++ b/ace_next/runners/claude_code.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from pipeline import Pipeline
-from pipeline.protocol import SampleResult
+from pipeline.protocol import SampleResult, StepProtocol
 
 from ..core.context import ACEStepContext, SkillbookView
 from ..core.skillbook import Skillbook
@@ -47,6 +47,82 @@ class ClaudeCode(ACERunner):
     """
 
     @classmethod
+    def build_steps(
+        cls,
+        *,
+        reflector: ReflectorLike,
+        skill_manager: SkillManagerLike,
+        skillbook: Skillbook | None = None,
+        skillbook_path: Optional[str] = None,
+        working_dir: Optional[str] = None,
+        timeout: int = 600,
+        model: Optional[str] = None,
+        allowed_tools: Optional[list[str]] = None,
+        dedup_config: Optional[DeduplicationConfig] = None,
+        dedup_manager: DeduplicationManagerLike | None = None,
+        dedup_interval: int = 10,
+        checkpoint_dir: str | Path | None = None,
+        checkpoint_interval: int = 10,
+    ) -> list[StepProtocol]:
+        """Return the steps that ``from_roles()`` would compose.
+
+        Use this to inspect, modify, or extend the pipeline before
+        constructing it yourself::
+
+            steps = ClaudeCode.build_steps(reflector=r, skill_manager=sm, ...)
+            steps.insert(2, MyCustomStep())
+            pipe = Pipeline(steps)
+            runner = ACERunner(pipeline=pipe, skillbook=skillbook)
+
+        Args:
+            reflector: Reflector role for analysing execution traces.
+            skill_manager: SkillManager role for update operations.
+            skillbook: Starting skillbook.  Creates an empty one if ``None``.
+            skillbook_path: Path to load skillbook from.
+            working_dir: Directory where Claude Code executes.
+            timeout: Execution timeout in seconds.
+            model: Optional Claude model override.
+            allowed_tools: Optional list of allowed tools.
+            dedup_config: Deduplication configuration.
+            dedup_manager: Optional pre-built deduplication manager.
+            dedup_interval: Samples between deduplication runs.
+            checkpoint_dir: Directory for checkpoint files.
+            checkpoint_interval: Samples between checkpoint saves.
+        """
+        # Resolve skillbook
+        if skillbook_path:
+            skillbook = Skillbook.load_from_file(skillbook_path)
+        elif skillbook is None:
+            skillbook = Skillbook()
+
+        # Resolve dedup manager
+        dm = dedup_manager
+        if dm is None and dedup_config is not None:
+            from ..deduplication import DeduplicationManager
+
+            dm = DeduplicationManager(dedup_config)
+
+        steps: list[StepProtocol] = [
+            ClaudeCodeExecuteStep(
+                working_dir=working_dir,
+                timeout=timeout,
+                model=model,
+                allowed_tools=allowed_tools,
+            ),
+            ClaudeCodeToTrace(),
+            *learning_tail(
+                reflector,
+                skill_manager,
+                skillbook,
+                dedup_manager=dm,
+                dedup_interval=dedup_interval,
+                checkpoint_dir=checkpoint_dir,
+                checkpoint_interval=checkpoint_interval,
+            ),
+        ]
+        return steps
+
+    @classmethod
     def from_roles(
         cls,
         *,
@@ -81,37 +157,26 @@ class ClaudeCode(ACERunner):
             checkpoint_dir: Directory for checkpoint files.
             checkpoint_interval: Samples between checkpoint saves.
         """
-        # Resolve skillbook
+        # Resolve skillbook (must match build_steps resolution)
         if skillbook_path:
             skillbook = Skillbook.load_from_file(skillbook_path)
         elif skillbook is None:
             skillbook = Skillbook()
 
-        # Resolve dedup manager
-        dm = dedup_manager
-        if dm is None and dedup_config is not None:
-            from ..deduplication import DeduplicationManager
-
-            dm = DeduplicationManager(dedup_config)
-
-        steps = [
-            ClaudeCodeExecuteStep(
-                working_dir=working_dir,
-                timeout=timeout,
-                model=model,
-                allowed_tools=allowed_tools,
-            ),
-            ClaudeCodeToTrace(),
-            *learning_tail(
-                reflector,
-                skill_manager,
-                skillbook,
-                dedup_manager=dm,
-                dedup_interval=dedup_interval,
-                checkpoint_dir=checkpoint_dir,
-                checkpoint_interval=checkpoint_interval,
-            ),
-        ]
+        steps = cls.build_steps(
+            reflector=reflector,
+            skill_manager=skill_manager,
+            skillbook=skillbook,
+            working_dir=working_dir,
+            timeout=timeout,
+            model=model,
+            allowed_tools=allowed_tools,
+            dedup_config=dedup_config,
+            dedup_manager=dedup_manager,
+            dedup_interval=dedup_interval,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_interval=checkpoint_interval,
+        )
         return cls(pipeline=Pipeline(steps), skillbook=skillbook)
 
     @classmethod

--- a/ace_next/runners/langchain.py
+++ b/ace_next/runners/langchain.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from pipeline import Pipeline
-from pipeline.protocol import SampleResult
+from pipeline.protocol import SampleResult, StepProtocol
 
 from ..core.context import ACEStepContext, SkillbookView
 from ..core.skillbook import Skillbook
@@ -49,6 +49,73 @@ class LangChain(ACERunner):
     """
 
     @classmethod
+    def build_steps(
+        cls,
+        *,
+        runnable: Any,
+        reflector: ReflectorLike,
+        skill_manager: SkillManagerLike,
+        skillbook: Skillbook | None = None,
+        skillbook_path: Optional[str] = None,
+        output_parser: Optional[Callable[[Any], str]] = None,
+        dedup_config: Optional[DeduplicationConfig] = None,
+        dedup_manager: DeduplicationManagerLike | None = None,
+        dedup_interval: int = 10,
+        checkpoint_dir: str | Path | None = None,
+        checkpoint_interval: int = 10,
+    ) -> list[StepProtocol]:
+        """Return the steps that ``from_roles()`` would compose.
+
+        Use this to inspect, modify, or extend the pipeline before
+        constructing it yourself::
+
+            steps = LangChain.build_steps(runnable=chain, reflector=r, ...)
+            steps.insert(2, MyCustomStep())
+            pipe = Pipeline(steps)
+            runner = ACERunner(pipeline=pipe, skillbook=skillbook)
+
+        Args:
+            runnable: Any LangChain Runnable (chain, AgentExecutor, LangGraph).
+            reflector: Reflector role for analysing execution traces.
+            skill_manager: SkillManager role for update operations.
+            skillbook: Starting skillbook.  Creates an empty one if ``None``.
+            skillbook_path: Path to load skillbook from.
+            output_parser: Custom function to extract a string from runnable output.
+            dedup_config: Deduplication configuration.
+            dedup_manager: Optional pre-built deduplication manager.
+            dedup_interval: Samples between deduplication runs.
+            checkpoint_dir: Directory for checkpoint files.
+            checkpoint_interval: Samples between checkpoint saves.
+        """
+        # Resolve skillbook
+        if skillbook_path:
+            skillbook = Skillbook.load_from_file(skillbook_path)
+        elif skillbook is None:
+            skillbook = Skillbook()
+
+        # Resolve dedup manager
+        dm = dedup_manager
+        if dm is None and dedup_config is not None:
+            from ..deduplication import DeduplicationManager
+
+            dm = DeduplicationManager(dedup_config)
+
+        steps: list[StepProtocol] = [
+            LangChainExecuteStep(runnable, output_parser=output_parser),
+            LangChainToTrace(),
+            *learning_tail(
+                reflector,
+                skill_manager,
+                skillbook,
+                dedup_manager=dm,
+                dedup_interval=dedup_interval,
+                checkpoint_dir=checkpoint_dir,
+                checkpoint_interval=checkpoint_interval,
+            ),
+        ]
+        return steps
+
+    @classmethod
     def from_roles(
         cls,
         *,
@@ -79,32 +146,24 @@ class LangChain(ACERunner):
             checkpoint_dir: Directory for checkpoint files.
             checkpoint_interval: Samples between checkpoint saves.
         """
-        # Resolve skillbook
+        # Resolve skillbook (must match build_steps resolution)
         if skillbook_path:
             skillbook = Skillbook.load_from_file(skillbook_path)
         elif skillbook is None:
             skillbook = Skillbook()
 
-        # Resolve dedup manager
-        dm = dedup_manager
-        if dm is None and dedup_config is not None:
-            from ..deduplication import DeduplicationManager
-
-            dm = DeduplicationManager(dedup_config)
-
-        steps = [
-            LangChainExecuteStep(runnable, output_parser=output_parser),
-            LangChainToTrace(),
-            *learning_tail(
-                reflector,
-                skill_manager,
-                skillbook,
-                dedup_manager=dm,
-                dedup_interval=dedup_interval,
-                checkpoint_dir=checkpoint_dir,
-                checkpoint_interval=checkpoint_interval,
-            ),
-        ]
+        steps = cls.build_steps(
+            runnable=runnable,
+            reflector=reflector,
+            skill_manager=skill_manager,
+            skillbook=skillbook,
+            output_parser=output_parser,
+            dedup_config=dedup_config,
+            dedup_manager=dedup_manager,
+            dedup_interval=dedup_interval,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_interval=checkpoint_interval,
+        )
         return cls(pipeline=Pipeline(steps), skillbook=skillbook)
 
     @classmethod

--- a/ace_next/runners/trace_analyser.py
+++ b/ace_next/runners/trace_analyser.py
@@ -37,6 +37,54 @@ class TraceAnalyser(ACERunner):
     """
 
     @classmethod
+    def build_steps(
+        cls,
+        *,
+        reflector: ReflectorLike,
+        skill_manager: SkillManagerLike,
+        skillbook: Skillbook | None = None,
+        dedup_manager: DeduplicationManagerLike | None = None,
+        dedup_interval: int = 10,
+        checkpoint_dir: str | Path | None = None,
+        checkpoint_interval: int = 10,
+        extra_steps: list[StepProtocol] | None = None,
+    ) -> list[StepProtocol]:
+        """Return the steps that ``from_roles()`` would compose.
+
+        Use this to inspect, modify, or extend the pipeline before
+        constructing it yourself::
+
+            steps = TraceAnalyser.build_steps(reflector=r, skill_manager=sm, ...)
+            steps.append(MyCustomStep())
+            pipe = Pipeline(steps)
+            runner = ACERunner(pipeline=pipe, skillbook=skillbook)
+
+        Args:
+            reflector: Reflector role for analysing traces.
+            skill_manager: SkillManager role for producing update operations.
+            skillbook: Starting skillbook.  Creates an empty one if ``None``.
+            dedup_manager: Optional deduplication manager.
+            dedup_interval: Samples between deduplication runs.
+            checkpoint_dir: Directory for checkpoint files.
+            checkpoint_interval: Samples between checkpoint saves.
+            extra_steps: Additional steps appended after the learning
+                tail (e.g. ``OpikStep``).
+        """
+        skillbook = skillbook or Skillbook()
+        steps = learning_tail(
+            reflector,
+            skill_manager,
+            skillbook,
+            dedup_manager=dedup_manager,
+            dedup_interval=dedup_interval,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_interval=checkpoint_interval,
+        )
+        if extra_steps:
+            steps.extend(extra_steps)
+        return steps
+
+    @classmethod
     def from_roles(
         cls,
         *,
@@ -65,17 +113,16 @@ class TraceAnalyser(ACERunner):
                 tail (e.g. ``OpikStep``).
         """
         skillbook = skillbook or Skillbook()
-        steps = learning_tail(
-            reflector,
-            skill_manager,
-            skillbook,
+        steps = cls.build_steps(
+            reflector=reflector,
+            skill_manager=skill_manager,
+            skillbook=skillbook,
             dedup_manager=dedup_manager,
             dedup_interval=dedup_interval,
             checkpoint_dir=checkpoint_dir,
             checkpoint_interval=checkpoint_interval,
+            extra_steps=extra_steps,
         )
-        if extra_steps:
-            steps.extend(extra_steps)
         return cls(pipeline=Pipeline(steps), skillbook=skillbook)
 
     def run(

--- a/docs/ACE_DESIGN.md
+++ b/docs/ACE_DESIGN.md
@@ -589,6 +589,39 @@ Reusable step implementations live in `ace_next/steps/`. Each is a single class 
 
 **Design principle: steps are stateless.** A step's `__call__` is a pure function of its constructor arguments and the incoming `ACEStepContext`. No internal counters, no accumulated state between invocations. If a step needs run-scoped information (like a global sample index for interval logic), the runner computes it and places it on the context. This keeps steps predictable across multiple `run()` calls — behaviour depends only on what's in the context, not on invocation history.
 
+### Public API
+
+All pipeline primitives, ACE steps, and context types are importable from `ace_next`:
+
+```python
+# Pipeline engine
+from ace_next import Pipeline, Branch, MergeStrategy, StepProtocol, SampleResult
+
+# ACE context
+from ace_next import ACEStepContext, SkillbookView
+
+# Runner base class (for custom runners)
+from ace_next import ACERunner
+
+# Core steps
+from ace_next import (
+    AgentStep, EvaluateStep, ReflectStep, TagStep, UpdateStep, ApplyStep,
+    DeduplicateStep, CheckpointStep, LoadTracesStep, ExportSkillbookMarkdownStep,
+    ObservabilityStep, PersistStep, learning_tail,
+)
+```
+
+Integration steps live in `ace_next.integrations` (they have framework-specific dependencies):
+
+```python
+from ace_next.integrations.browser_use import BrowserExecuteStep, BrowserToTrace
+from ace_next.integrations.langchain import LangChainExecuteStep, LangChainToTrace
+from ace_next.integrations.claude_code import ClaudeCodeExecuteStep, ClaudeCodeToTrace
+from ace_next.integrations.openclaw import OpenClawToTraceStep
+```
+
+Every runner also exposes a `build_steps()` classmethod that returns the step list it would compose internally, enabling users to inspect, modify, and recompose pipelines. See the [Composing Pipelines](guides/composing-pipelines.md) guide.
+
 ### Step Summary
 
 | Step | Requires (context) | Injected (constructor) | Provides | Side effects | `max_workers` |

--- a/docs/guides/composing-pipelines.md
+++ b/docs/guides/composing-pipelines.md
@@ -1,0 +1,236 @@
+# Composing Custom Pipelines
+
+ACE is built on a composable pipeline engine. Every runner (`ACE`, `BrowserUse`,
+`LangChain`, `ClaudeCode`, `TraceAnalyser`) is a thin wrapper around a `Pipeline`
+made of steps. You can compose your own pipelines by mixing and matching these
+steps — or writing custom ones.
+
+## Three Levels of ACE
+
+| Level | Pattern | Control |
+|-------|---------|---------|
+| **Zero-config** | `ACELiteLLM.from_model("gpt-4o-mini")` | Roles + pipeline auto-created |
+| **Role customisation** | `ACE.from_roles(agent=..., reflector=..., ...)` | Custom roles, pipeline auto-composed |
+| **Pipeline composition** | `Pipeline([AgentStep(...), ...])` | Full control over step ordering |
+
+This guide covers **Level 3** — composing pipelines directly.
+
+## Anatomy of an ACE Pipeline
+
+Every ACE pipeline is a sequence of steps, each with a `requires`/`provides`
+contract that declares what context fields it reads and writes:
+
+```
+AgentStep ─────> EvaluateStep ─────> ReflectStep ─────> TagStep ─────> UpdateStep ─────> ApplyStep
+  provides:        provides:           provides:          (metadata)    provides:         (mutates
+  agent_output     trace                reflection                      skill_manager     skillbook)
+                                                                        _output
+```
+
+The pipeline validates these contracts at construction time — if a step requires
+a field that no earlier step provides, you'll get an error immediately.
+
+## Composing from Steps
+
+All pipeline classes and ACE steps are importable from `ace_next`:
+
+```python
+from ace_next import (
+    # Pipeline engine
+    Pipeline, Branch, MergeStrategy, StepProtocol, SampleResult,
+    # ACE context
+    ACEStepContext, SkillbookView,
+    # Roles
+    Agent, Reflector, SkillManager,
+    # Steps
+    AgentStep, EvaluateStep, learning_tail,
+    # Types
+    LiteLLMClient, Sample, Skillbook, SimpleEnvironment,
+)
+
+llm = LiteLLMClient(model="gpt-4o-mini")
+skillbook = Skillbook()
+
+pipe = Pipeline([
+    AgentStep(Agent(llm)),
+    EvaluateStep(SimpleEnvironment()),
+    *learning_tail(Reflector(llm), SkillManager(llm), skillbook),
+])
+```
+
+## Using `learning_tail()`
+
+The `learning_tail()` helper returns the standard learning step sequence:
+
+```python
+from ace_next import learning_tail, Reflector, SkillManager, Skillbook
+
+steps = learning_tail(
+    Reflector(llm),
+    SkillManager(llm),
+    Skillbook(),
+    dedup_manager=my_dedup_manager,      # optional
+    checkpoint_dir="/tmp/checkpoints",    # optional
+)
+# Returns: [ReflectStep, TagStep, UpdateStep, ApplyStep,
+#           DeduplicateStep, CheckpointStep]
+```
+
+Use it when building custom integrations that provide their own execute step but
+want the standard learning pipeline.
+
+## Inspecting Runner Presets with `build_steps()`
+
+Every runner has a `build_steps()` classmethod that returns the step list it
+would use internally. This lets you inspect, modify, and recompose:
+
+```python
+from ace_next import ACE, Pipeline, ACERunner, Skillbook
+
+# Get the default steps
+steps = ACE.build_steps(
+    agent=my_agent,
+    reflector=my_reflector,
+    skill_manager=my_skill_manager,
+    environment=my_env,
+)
+
+# Insert a custom step after EvaluateStep
+steps.insert(2, MyLoggingStep())
+
+# Build your own pipeline and runner
+skillbook = Skillbook()
+pipe = Pipeline(steps)
+runner = ACERunner(pipeline=pipe, skillbook=skillbook)
+results = runner.run(samples)
+```
+
+All runners support `build_steps()`: `ACE`, `BrowserUse`, `ClaudeCode`,
+`LangChain`, and `TraceAnalyser`.
+
+## Writing Custom Steps
+
+A step is any object satisfying `StepProtocol` — no base class needed:
+
+```python
+from ace_next import ACEStepContext
+
+class MyLoggingStep:
+    requires = frozenset({"agent_output"})
+    provides = frozenset()
+
+    def __call__(self, ctx: ACEStepContext) -> ACEStepContext:
+        print(f"Agent answered: {ctx.agent_output.final_answer}")
+        return ctx
+```
+
+Key rules:
+
+- `requires`: frozenset of context field names this step reads
+- `provides`: frozenset of context field names this step writes
+- `__call__`: receives and returns `ACEStepContext` (use `ctx.replace(...)` for updates)
+- Steps should be stateless — no internal counters
+
+## Mixing Integrations
+
+You can compose steps from different integrations into one pipeline. For example,
+combining a browser-use execute step with custom learning:
+
+```python
+from ace_next import Pipeline, learning_tail, Reflector, SkillManager, Skillbook
+from ace_next.integrations.browser_use import BrowserExecuteStep, BrowserToTrace
+
+skillbook = Skillbook()
+pipe = Pipeline([
+    BrowserExecuteStep(browser_llm),
+    BrowserToTrace(),
+    MyCustomFilterStep(),  # your custom step
+    *learning_tail(Reflector(llm), SkillManager(llm), skillbook),
+])
+```
+
+Integration steps live in `ace_next.integrations` since they have
+framework-specific dependencies.
+
+## Running the Pipeline
+
+### With a runner
+
+The simplest way to run a custom pipeline is through `ACERunner`:
+
+```python
+from ace_next import ACERunner, Sample, Skillbook
+
+runner = ACERunner(pipeline=pipe, skillbook=skillbook)
+results = runner.run(
+    [Sample(question="What is 2+2?", ground_truth="4")],
+    epochs=1,
+)
+```
+
+### Directly
+
+You can also run the pipeline directly by constructing contexts yourself:
+
+```python
+from ace_next import Pipeline, ACEStepContext, SkillbookView, Sample, Skillbook
+
+ctx = ACEStepContext(
+    sample=Sample(question="What is 2+2?", ground_truth="4"),
+    skillbook=SkillbookView(skillbook),
+)
+
+results = pipe.run([ctx])
+pipe.wait_for_background()  # wait for async learning steps
+```
+
+## Branching (Parallel Steps)
+
+The pipeline engine supports parallel branches for steps that can run
+concurrently:
+
+```python
+from ace_next import Pipeline, Branch, MergeStrategy
+
+pipe = Pipeline([
+    AgentStep(agent),
+    Branch(
+        [EvaluateStep(env_a), EvaluateStep(env_b)],
+        merge=MergeStrategy.LAST,
+    ),
+    *learning_tail(reflector, skill_manager, skillbook),
+])
+```
+
+See the [Pipeline Engine docs](../pipeline/branching.md) for full branching
+and merge strategy details.
+
+## Available Steps
+
+All steps are importable from `ace_next`:
+
+| Step | Purpose |
+|------|---------|
+| `AgentStep` | Execute Agent role |
+| `EvaluateStep` | Run TaskEnvironment evaluation |
+| `ReflectStep` | Run Reflector role (async boundary) |
+| `TagStep` | Tag skills for update |
+| `UpdateStep` | Run SkillManager to generate updates |
+| `ApplyStep` | Apply updates to skillbook |
+| `DeduplicateStep` | Merge near-duplicate skills |
+| `CheckpointStep` | Save skillbook to disk |
+| `LoadTracesStep` | Load JSONL trace files |
+| `ExportSkillbookMarkdownStep` | Export skillbook as markdown |
+| `ObservabilityStep` | Generic observability hook |
+| `PersistStep` | Persist step output |
+| `OpikStep` | Log traces to Opik |
+| `RRStep` | Recursive Reflector |
+
+Integration steps (in `ace_next.integrations`):
+
+| Step | Integration |
+|------|-------------|
+| `BrowserExecuteStep` / `BrowserToTrace` | browser-use |
+| `LangChainExecuteStep` / `LangChainToTrace` | LangChain |
+| `ClaudeCodeExecuteStep` / `ClaudeCodeToTrace` | Claude Code |
+| `OpenClawToTraceStep` | OpenClaw |

--- a/docs/guides/full-pipeline.md
+++ b/docs/guides/full-pipeline.md
@@ -228,8 +228,27 @@ register_opik_litellm_callback(project_name="my-experiment")
 
 See [Opik Observability](../integrations/opik.md) for full details.
 
+## Going Deeper: Manual Pipeline Composition
+
+The `ACE.from_roles()` runner composes a `Pipeline` internally. You can build the
+same pipeline yourself for full control over step ordering, branching, and
+custom steps:
+
+```python
+from ace_next import Pipeline, AgentStep, EvaluateStep, learning_tail
+
+pipe = Pipeline([
+    AgentStep(agent),
+    EvaluateStep(environment),
+    *learning_tail(reflector, skill_manager, skillbook),
+])
+```
+
+See [Composing Pipelines](composing-pipelines.md) for the complete guide.
+
 ## What to Read Next
 
+- [Composing Pipelines](composing-pipelines.md) — compose custom pipelines from steps
 - [Async Learning](async-learning.md) — parallel Reflector execution
 - [Prompt Engineering](prompts.md) — customize prompt templates
 - [Integration Pattern](integration.md) — wrap existing agents instead

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,15 @@ pip install ace-framework
 
     [:octicons-arrow-right-24: Integrations Overview](integrations/index.md)
 
+-   **Pipeline Composition**
+
+    ---
+
+    Compose custom pipelines by mixing and matching steps for full control.
+
+    [:octicons-arrow-right-24: Composing Pipelines](guides/composing-pipelines.md)
+    [:octicons-arrow-right-24: Pipeline Engine](pipeline/index.md)
+
 </div>
 
 ## Available Runners

--- a/docs/pipeline/index.md
+++ b/docs/pipeline/index.md
@@ -152,6 +152,11 @@ The pipeline engine is included in the project with no extra dependencies:
 from pipeline import Pipeline, Branch, StepContext, MergeStrategy
 ```
 
+!!! tip "Using the Pipeline Engine with ACE"
+    If you're building ACE pipelines, see [Composing Pipelines](../guides/composing-pipelines.md)
+    for ACE-specific steps and patterns. All pipeline classes are also importable
+    from `ace_next` directly: `from ace_next import Pipeline, Branch, ...`
+
 ---
 
 ## What's Next

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,11 @@ Add ACE learning to existing systems:
 
 Shows the three-step integration: Inject → Execute → Learn
 
+### Pipeline Composition
+**[pipeline_composition/](pipeline_composition/)** - Build custom ACE pipelines
+
+- [compose_custom_pipeline.py](pipeline_composition/compose_custom_pipeline.py) - Mix and match steps, add custom steps, use `build_steps()`
+
 ## 📊 Advanced Topics
 
 ### Production Learning
@@ -65,6 +70,7 @@ Shows the three-step integration: Inject → Execute → Learn
 | Browser automation | [browser-use/](browser-use/) |
 | LangChain workflows | [langchain/](langchain/) |
 | Custom agents | [custom_integration_example.py](custom_integration_example.py) |
+| Custom pipelines | [pipeline_composition/](pipeline_composition/) |
 | Production learning | [helicone/](helicone/) |
 | Prompt optimization | [prompts/](prompts/) |
 

--- a/examples/ace_next/ace_next_demo.py
+++ b/examples/ace_next/ace_next_demo.py
@@ -273,16 +273,13 @@ for epoch in range(1, 3):
 #
 # Under the hood, runners compose `Pipeline` objects from individual steps.
 # Here we build one by hand to see exactly what each step does.
+# All pipeline classes and steps are importable directly from `ace_next`.
 
 # %%
-from pipeline import Pipeline
-from ace_next.steps import (
+from ace_next import (
+    Pipeline,
     AgentStep,
     EvaluateStep,
-    ReflectStep,
-    TagStep,
-    UpdateStep,
-    ApplyStep,
     learning_tail,
 )
 

--- a/examples/pipeline_composition/compose_custom_pipeline.py
+++ b/examples/pipeline_composition/compose_custom_pipeline.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Compose a custom ACE pipeline from individual steps.
+
+Demonstrates:
+  1. Pipeline composition with a single import line from ace_next
+  2. Adding a custom step to the pipeline
+  3. Inspecting runner presets via build_steps()
+  4. Running the pipeline directly via ACERunner
+
+Requires:
+  pip install ace-framework
+  export OPENAI_API_KEY=...  # or any LiteLLM-supported provider
+"""
+
+from __future__ import annotations
+
+from ace_next import (
+    # Pipeline engine
+    Pipeline,
+    StepProtocol,
+    # ACE context
+    ACEStepContext,
+    ACERunner,
+    # Roles
+    Agent,
+    Reflector,
+    SkillManager,
+    # Steps
+    AgentStep,
+    EvaluateStep,
+    learning_tail,
+    # Types
+    ACE,
+    LiteLLMClient,
+    Sample,
+    Skillbook,
+    SimpleEnvironment,
+)
+
+
+# ------------------------------------------------------------------
+# 1. Custom step — print the agent's answer between execute and learn
+# ------------------------------------------------------------------
+
+
+class LogAnswerStep:
+    """A custom step that logs the agent's output before learning."""
+
+    requires = frozenset({"agent_output"})
+    provides = frozenset()
+
+    def __call__(self, ctx: ACEStepContext) -> ACEStepContext:
+        print(f"  -> Agent answered: {ctx.agent_output.final_answer}")
+        return ctx
+
+
+# ------------------------------------------------------------------
+# 2. Compose a custom pipeline
+# ------------------------------------------------------------------
+
+MODEL = "gpt-4o-mini"
+
+llm = LiteLLMClient(model=MODEL)
+skillbook = Skillbook()
+
+pipe = Pipeline(
+    [
+        AgentStep(Agent(llm)),
+        EvaluateStep(SimpleEnvironment()),
+        LogAnswerStep(),  # <-- custom step injected here
+        *learning_tail(Reflector(llm), SkillManager(llm), skillbook),
+    ]
+)
+
+print(f"Custom pipeline: {len(pipe._steps)} steps")
+print(f"  requires: {pipe.requires}")
+print(f"  provides: {pipe.provides}")
+
+# ------------------------------------------------------------------
+# 3. Run using ACERunner
+# ------------------------------------------------------------------
+
+runner = ACERunner(pipeline=pipe, skillbook=skillbook)
+
+samples = [
+    Sample(question="What is 2+2?", context="", ground_truth="4"),
+    Sample(question="Capital of France?", context="", ground_truth="Paris"),
+]
+
+# Note: ACERunner._build_context is abstract, so we use ACE which
+# provides _build_context for Sample objects.
+runner_ace = ACE(pipeline=pipe, skillbook=skillbook)
+results = runner_ace.run(samples, epochs=1)
+
+print(f"\nResults: {len(results)} samples processed")
+print(f"Skills learned: {len(skillbook.skills())}")
+
+# ------------------------------------------------------------------
+# 4. Inspect and modify a runner's default steps with build_steps()
+# ------------------------------------------------------------------
+
+print("\n--- Inspecting ACE.build_steps() ---")
+default_steps = ACE.build_steps(
+    agent=Agent(llm),
+    reflector=Reflector(llm),
+    skill_manager=SkillManager(llm),
+    environment=SimpleEnvironment(),
+    skillbook=Skillbook(),
+)
+
+for i, step in enumerate(default_steps):
+    print(f"  [{i}] {type(step).__name__}")
+
+# Modify: insert LogAnswerStep after EvaluateStep
+default_steps.insert(2, LogAnswerStep())
+print(f"\nAfter inserting LogAnswerStep: {len(default_steps)} steps")
+
+# Build a new pipeline from the modified steps
+modified_pipe = Pipeline(default_steps)
+print(f"Modified pipeline ready with {len(modified_pipe._steps)} steps")

--- a/tests/test_pipeline_exports.py
+++ b/tests/test_pipeline_exports.py
@@ -1,0 +1,238 @@
+"""Tests that pipeline composition classes are importable from ace_next.
+
+Verifies the public API surface for pipeline-first composition.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from ace_next.core.outputs import (
+    AgentOutput,
+    ReflectorOutput,
+    SkillManagerOutput,
+)
+from ace_next.core.skillbook import Skillbook, UpdateBatch, UpdateOperation
+
+
+# ------------------------------------------------------------------ #
+# Mock roles for build_steps() tests
+# ------------------------------------------------------------------ #
+
+
+class MockAgent:
+    def run(self, *a: Any, **kw: Any) -> AgentOutput:
+        return AgentOutput(reasoning="r", final_answer="a")
+
+
+class MockReflector:
+    def reflect(self, *a: Any, **kw: Any) -> ReflectorOutput:
+        return ReflectorOutput(
+            reasoning="r",
+            correct_approach="a",
+            key_insight="i",
+            skill_tags=[],
+        )
+
+
+class MockSkillManager:
+    def update_skills(self, *a: Any, **kw: Any) -> SkillManagerOutput:
+        return SkillManagerOutput(
+            update=UpdateBatch(
+                reasoning="r",
+                operations=[
+                    UpdateOperation(type="ADD", section="learned", content="c")
+                ],
+            ),
+        )
+
+
+# ------------------------------------------------------------------ #
+# Pipeline primitives are importable from ace_next
+# ------------------------------------------------------------------ #
+
+
+class TestPipelineExports:
+    def test_pipeline_class(self):
+        from ace_next import Pipeline
+
+        assert Pipeline is not None
+
+    def test_branch_class(self):
+        from ace_next import Branch
+
+        assert Branch is not None
+
+    def test_merge_strategy(self):
+        from ace_next import MergeStrategy
+
+        assert MergeStrategy is not None
+
+    def test_step_protocol(self):
+        from ace_next import StepProtocol
+
+        assert StepProtocol is not None
+
+    def test_sample_result(self):
+        from ace_next import SampleResult
+
+        assert SampleResult is not None
+
+
+# ------------------------------------------------------------------ #
+# ACE context types are importable from ace_next
+# ------------------------------------------------------------------ #
+
+
+class TestContextExports:
+    def test_ace_step_context(self):
+        from ace_next import ACEStepContext
+
+        assert ACEStepContext is not None
+
+    def test_skillbook_view(self):
+        from ace_next import SkillbookView
+
+        assert SkillbookView is not None
+
+    def test_ace_runner(self):
+        from ace_next import ACERunner
+
+        assert ACERunner is not None
+
+
+# ------------------------------------------------------------------ #
+# All steps are importable from ace_next
+# ------------------------------------------------------------------ #
+
+
+class TestStepExports:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "AgentStep",
+            "EvaluateStep",
+            "ReflectStep",
+            "TagStep",
+            "UpdateStep",
+            "ApplyStep",
+            "DeduplicateStep",
+            "CheckpointStep",
+            "LoadTracesStep",
+            "ExportSkillbookMarkdownStep",
+            "ObservabilityStep",
+            "PersistStep",
+            "learning_tail",
+        ],
+    )
+    def test_step_importable(self, name: str):
+        import ace_next
+
+        assert hasattr(ace_next, name), f"{name} not in ace_next"
+
+    def test_all_steps_in_dunder_all(self):
+        import ace_next
+
+        step_names = [
+            "AgentStep",
+            "EvaluateStep",
+            "ReflectStep",
+            "TagStep",
+            "UpdateStep",
+            "ApplyStep",
+            "DeduplicateStep",
+            "CheckpointStep",
+            "LoadTracesStep",
+            "ExportSkillbookMarkdownStep",
+            "ObservabilityStep",
+            "PersistStep",
+            "learning_tail",
+        ]
+        for name in step_names:
+            assert name in ace_next.__all__, f"{name} not in __all__"
+
+
+# ------------------------------------------------------------------ #
+# build_steps() returns expected step types
+# ------------------------------------------------------------------ #
+
+
+class TestBuildSteps:
+    def test_ace_build_steps(self):
+        from ace_next import ACE
+        from ace_next.steps import AgentStep, EvaluateStep, ReflectStep
+
+        steps = ACE.build_steps(
+            agent=MockAgent(),
+            reflector=MockReflector(),
+            skill_manager=MockSkillManager(),
+        )
+        assert isinstance(steps, list)
+        assert len(steps) >= 4  # Agent, Evaluate, Reflect, Tag, Update, Apply
+        assert isinstance(steps[0], AgentStep)
+        assert isinstance(steps[1], EvaluateStep)
+        assert isinstance(steps[2], ReflectStep)
+
+    def test_trace_analyser_build_steps(self):
+        from ace_next import TraceAnalyser
+        from ace_next.steps import ReflectStep
+
+        steps = TraceAnalyser.build_steps(
+            reflector=MockReflector(),
+            skill_manager=MockSkillManager(),
+        )
+        assert isinstance(steps, list)
+        assert len(steps) >= 4  # Reflect, Tag, Update, Apply
+        assert isinstance(steps[0], ReflectStep)
+
+    def test_ace_from_roles_delegates_to_build_steps(self):
+        """from_roles() should produce the same steps as build_steps()."""
+        from ace_next import ACE
+
+        kwargs = dict(
+            agent=MockAgent(),
+            reflector=MockReflector(),
+            skill_manager=MockSkillManager(),
+        )
+        runner = ACE.from_roles(**kwargs)
+        steps = ACE.build_steps(**kwargs)
+
+        # Same number of steps
+        assert len(runner.pipeline._steps) == len(steps)
+        # Same step types
+        for pipe_step, built_step in zip(runner.pipeline._steps, steps):
+            assert type(pipe_step) is type(built_step)
+
+    def test_build_steps_with_extra_steps(self):
+        from ace_next import ACE
+
+        class DummyStep:
+            requires = frozenset()
+            provides = frozenset()
+
+            def __call__(self, ctx):
+                return ctx
+
+        steps = ACE.build_steps(
+            agent=MockAgent(),
+            reflector=MockReflector(),
+            skill_manager=MockSkillManager(),
+            extra_steps=[DummyStep()],
+        )
+        assert isinstance(steps[-1], DummyStep)
+
+    def test_pipeline_from_build_steps(self):
+        """Pipeline constructed from build_steps() should be valid."""
+        from ace_next import ACE, Pipeline
+
+        steps = ACE.build_steps(
+            agent=MockAgent(),
+            reflector=MockReflector(),
+            skill_manager=MockSkillManager(),
+        )
+        pipe = Pipeline(steps)
+        assert pipe is not None
+        assert len(pipe._steps) == len(steps)


### PR DESCRIPTION
## Summary

- Re-export `Pipeline`, `Branch`, `MergeStrategy`, `StepProtocol`, `SampleResult`, `ACEStepContext`, `SkillbookView`, `ACERunner`, all 13 step classes, and `learning_tail` from `ace_next` — users can now compose custom pipelines with a single import line
- Add `build_steps()` classmethods to all five runners (`ACE`, `BrowserUse`, `ClaudeCode`, `LangChain`, `TraceAnalyser`) so users can inspect, modify, and recompose runner presets before constructing their own `Pipeline`
- `from_roles()` now delegates to `build_steps()` internally (no behavior change)
- New `docs/guides/composing-pipelines.md` guide covering three levels of ACE usage, `learning_tail()`, `build_steps()`, custom steps, and integration mixing
- Updated existing docs (`full-pipeline.md`, `pipeline/index.md`, `ACE_DESIGN.md`, `index.md`) with cross-links
- New `examples/pipeline_composition/compose_custom_pipeline.py` example
- 27 new tests in `tests/test_pipeline_exports.py` verifying all exports and `build_steps()` behavior

## Test plan

- [x] `uv run pytest` — 990 passed, 0 failures
- [x] All new exports importable from `ace_next`
- [x] `build_steps()` returns expected step types for all runners
- [x] `from_roles()` delegation produces identical pipeline structure
- [ ] Verify docs render correctly with `mkdocs serve`