### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ pip install ace-framework
 
 ```bash
 export OPENAI_API_KEY="your-api-key"
+# Or use other providers:
+# export MINIMAX_API_KEY="your-minimax-api-key"
 ```
 
 ### 3. Run

--- a/ace/llm_providers/litellm_client.py
+++ b/ace/llm_providers/litellm_client.py
@@ -652,7 +652,9 @@ class LiteLLMClient(LLMClient):
         """Infer provider from model name."""
         model_lower = model.lower()
 
-        if "gpt" in model_lower or "openai" in model_lower:
+        if "minimax" in model_lower:
+            return "minimax"
+        elif "gpt" in model_lower or "openai" in model_lower:
             return "openai"
         elif "claude" in model_lower or "anthropic" in model_lower:
             return "anthropic"
@@ -703,6 +705,9 @@ class LiteLLMClient(LLMClient):
             "mistral-7b",
             "mistral-medium",
             "mixtral-8x7b",
+            # MiniMax (via OpenAI-compatible endpoint)
+            "openai/MiniMax-M2.5",
+            "openai/MiniMax-M2.5-highspeed",
             # Note: Many more models are supported
             # See: https://docs.litellm.ai/docs/providers
         ]

--- a/ace/llm_providers/litellm_client.py
+++ b/ace/llm_providers/litellm_client.py
@@ -706,6 +706,8 @@ class LiteLLMClient(LLMClient):
             "mistral-medium",
             "mixtral-8x7b",
             # MiniMax (via OpenAI-compatible endpoint)
+            "openai/MiniMax-M2.7",
+            "openai/MiniMax-M2.7-highspeed",
             "openai/MiniMax-M2.5",
             "openai/MiniMax-M2.5-highspeed",
             # Note: Many more models are supported

--- a/ace/llm_providers/litellm_client.py
+++ b/ace/llm_providers/litellm_client.py
@@ -706,10 +706,9 @@ class LiteLLMClient(LLMClient):
             "mistral-medium",
             "mixtral-8x7b",
             # MiniMax (via OpenAI-compatible endpoint)
+            "openai/MiniMax-M3",
             "openai/MiniMax-M2.7",
             "openai/MiniMax-M2.7-highspeed",
-            "openai/MiniMax-M2.5",
-            "openai/MiniMax-M2.5-highspeed",
             # Note: Many more models are supported
             # See: https://docs.litellm.ai/docs/providers
         ]

--- a/ace_next/providers/litellm.py
+++ b/ace_next/providers/litellm.py
@@ -537,7 +537,9 @@ class LiteLLMClient:
     def _get_provider_from_model(self, model: str) -> str:
         """Infer provider from model name."""
         model_lower = model.lower()
-        if "gpt" in model_lower or "openai" in model_lower:
+        if "minimax" in model_lower:
+            return "minimax"
+        elif "gpt" in model_lower or "openai" in model_lower:
             return "openai"
         elif "claude" in model_lower or "anthropic" in model_lower:
             return "anthropic"
@@ -569,4 +571,7 @@ class LiteLLMClient:
             "llama-2-70b",
             "mistral-7b",
             "mixtral-8x7b",
+            # MiniMax (via OpenAI-compatible endpoint)
+            "openai/MiniMax-M2.5",
+            "openai/MiniMax-M2.5-highspeed",
         ]

--- a/ace_next/providers/litellm.py
+++ b/ace_next/providers/litellm.py
@@ -572,6 +572,8 @@ class LiteLLMClient:
             "mistral-7b",
             "mixtral-8x7b",
             # MiniMax (via OpenAI-compatible endpoint)
+            "openai/MiniMax-M2.7",
+            "openai/MiniMax-M2.7-highspeed",
             "openai/MiniMax-M2.5",
             "openai/MiniMax-M2.5-highspeed",
         ]

--- a/ace_next/providers/litellm.py
+++ b/ace_next/providers/litellm.py
@@ -572,8 +572,7 @@ class LiteLLMClient:
             "mistral-7b",
             "mixtral-8x7b",
             # MiniMax (via OpenAI-compatible endpoint)
+            "openai/MiniMax-M3",
             "openai/MiniMax-M2.7",
             "openai/MiniMax-M2.7-highspeed",
-            "openai/MiniMax-M2.5",
-            "openai/MiniMax-M2.5-highspeed",
         ]

--- a/ace_next/providers/registry.py
+++ b/ace_next/providers/registry.py
@@ -43,6 +43,7 @@ PROVIDER_MODEL_EXAMPLES: dict[str, str] = {
     "ollama": "ollama/llama2",
     "azure": "azure/gpt-4",
     "openrouter": "openrouter/anthropic/claude-3.5-sonnet",
+    "minimax": "openai/MiniMax-M2.5",
 }
 
 
@@ -208,6 +209,7 @@ PROVIDER_KEY_ENV: dict[str, str | list[str]] = {
     "huggingface": "HUGGINGFACE_API_KEY",
     "perplexity": "PERPLEXITYAI_API_KEY",
     "anyscale": "ANYSCALE_API_KEY",
+    "minimax": "MINIMAX_API_KEY",
 }
 
 

--- a/ace_next/providers/registry.py
+++ b/ace_next/providers/registry.py
@@ -43,7 +43,7 @@ PROVIDER_MODEL_EXAMPLES: dict[str, str] = {
     "ollama": "ollama/llama2",
     "azure": "azure/gpt-4",
     "openrouter": "openrouter/anthropic/claude-3.5-sonnet",
-    "minimax": "openai/MiniMax-M2.5",
+    "minimax": "openai/MiniMax-M2.7",
 }
 
 

--- a/ace_next/providers/registry.py
+++ b/ace_next/providers/registry.py
@@ -43,7 +43,7 @@ PROVIDER_MODEL_EXAMPLES: dict[str, str] = {
     "ollama": "ollama/llama2",
     "azure": "azure/gpt-4",
     "openrouter": "openrouter/anthropic/claude-3.5-sonnet",
-    "minimax": "openai/MiniMax-M2.7",
+    "minimax": "openai/MiniMax-M3",
 }
 
 

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -176,6 +176,7 @@ ACE uses [LiteLLM](https://docs.litellm.ai/) for model access. Any model string 
 | Ollama (local) | `ollama/llama2` | --- |
 | Azure OpenAI | `azure/gpt-4` | `AZURE_API_KEY` |
 | OpenRouter | `openrouter/anthropic/claude-3.5-sonnet` | `OPENROUTER_API_KEY` |
+| MiniMax | `openai/MiniMax-M2.5` | `MINIMAX_API_KEY` |
 
 100+ providers supported. Run `ace models` to search the full catalog.
 

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -176,7 +176,7 @@ ACE uses [LiteLLM](https://docs.litellm.ai/) for model access. Any model string 
 | Ollama (local) | `ollama/llama2` | --- |
 | Azure OpenAI | `azure/gpt-4` | `AZURE_API_KEY` |
 | OpenRouter | `openrouter/anthropic/claude-3.5-sonnet` | `OPENROUTER_API_KEY` |
-| MiniMax | `openai/MiniMax-M2.5` | `MINIMAX_API_KEY` |
+| MiniMax | `openai/MiniMax-M2.7` | `MINIMAX_API_KEY` |
 
 100+ providers supported. Run `ace models` to search the full catalog.
 

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -176,7 +176,7 @@ ACE uses [LiteLLM](https://docs.litellm.ai/) for model access. Any model string 
 | Ollama (local) | `ollama/llama2` | --- |
 | Azure OpenAI | `azure/gpt-4` | `AZURE_API_KEY` |
 | OpenRouter | `openrouter/anthropic/claude-3.5-sonnet` | `OPENROUTER_API_KEY` |
-| MiniMax | `openai/MiniMax-M2.7` | `MINIMAX_API_KEY` |
+| MiniMax | `openai/MiniMax-M3` | `MINIMAX_API_KEY` |
 
 100+ providers supported. Run `ace models` to search the full catalog.
 

--- a/docs/integrations/litellm.md
+++ b/docs/integrations/litellm.md
@@ -139,7 +139,7 @@ agent = ACELiteLLM.from_model("gemini-pro")
 
 # MiniMax
 agent = ACELiteLLM.from_model(
-    "openai/MiniMax-M2.5",
+    "openai/MiniMax-M2.7",
     base_url="https://api.minimax.io/v1",
     api_key=os.environ["MINIMAX_API_KEY"],
 )
@@ -157,6 +157,8 @@ agent = ACELiteLLM.from_model("gpt-4o-mini", base_url="https://your-endpoint.com
 
 | Model | Description |
 |-------|-------------|
+| `MiniMax-M2.7` | Latest flagship model with enhanced reasoning and coding |
+| `MiniMax-M2.7-highspeed` | High-speed version of M2.7 for low-latency scenarios |
 | `MiniMax-M2.5` | Peak performance with 204K context window |
 | `MiniMax-M2.5-highspeed` | Same performance, faster and more agile |
 
@@ -169,7 +171,7 @@ from ace_next import ACELiteLLM
 
 # Using MiniMax as the agent model
 agent = ACELiteLLM.from_model(
-    "openai/MiniMax-M2.5",
+    "openai/MiniMax-M2.7",
     base_url="https://api.minimax.io/v1",
 )
 

--- a/docs/integrations/litellm.md
+++ b/docs/integrations/litellm.md
@@ -137,11 +137,43 @@ agent = ACELiteLLM.from_model("claude-sonnet-4-5-20250929")
 # Google
 agent = ACELiteLLM.from_model("gemini-pro")
 
+# MiniMax
+agent = ACELiteLLM.from_model(
+    "openai/MiniMax-M2.5",
+    base_url="https://api.minimax.io/v1",
+    api_key=os.environ["MINIMAX_API_KEY"],
+)
+
 # Local (Ollama)
 agent = ACELiteLLM.from_model("ollama/llama2")
 
 # Custom endpoint
 agent = ACELiteLLM.from_model("gpt-4o-mini", base_url="https://your-endpoint.com")
+```
+
+### MiniMax Models
+
+[MiniMax](https://platform.minimax.io/) provides high-performance models via an OpenAI-compatible API:
+
+| Model | Description |
+|-------|-------------|
+| `MiniMax-M2.5` | Peak performance with 204K context window |
+| `MiniMax-M2.5-highspeed` | Same performance, faster and more agile |
+
+```bash
+export MINIMAX_API_KEY="your-minimax-api-key"
+```
+
+```python
+from ace_next import ACELiteLLM
+
+# Using MiniMax as the agent model
+agent = ACELiteLLM.from_model(
+    "openai/MiniMax-M2.5",
+    base_url="https://api.minimax.io/v1",
+)
+
+answer = agent.ask("Explain quantum computing in simple terms")
 ```
 
 ## Opik Observability

--- a/docs/integrations/litellm.md
+++ b/docs/integrations/litellm.md
@@ -139,7 +139,7 @@ agent = ACELiteLLM.from_model("gemini-pro")
 
 # MiniMax
 agent = ACELiteLLM.from_model(
-    "openai/MiniMax-M2.7",
+    "openai/MiniMax-M3",
     base_url="https://api.minimax.io/v1",
     api_key=os.environ["MINIMAX_API_KEY"],
 )
@@ -157,10 +157,9 @@ agent = ACELiteLLM.from_model("gpt-4o-mini", base_url="https://your-endpoint.com
 
 | Model | Description |
 |-------|-------------|
-| `MiniMax-M2.7` | Latest flagship model with enhanced reasoning and coding |
+| `MiniMax-M3` | Latest flagship model with 512K context window, up to 128K output, and image input support (default) |
+| `MiniMax-M2.7` | Previous-generation flagship model with enhanced reasoning and coding |
 | `MiniMax-M2.7-highspeed` | High-speed version of M2.7 for low-latency scenarios |
-| `MiniMax-M2.5` | Peak performance with 204K context window |
-| `MiniMax-M2.5-highspeed` | Same performance, faster and more agile |
 
 ```bash
 export MINIMAX_API_KEY="your-minimax-api-key"
@@ -171,7 +170,7 @@ from ace_next import ACELiteLLM
 
 # Using MiniMax as the agent model
 agent = ACELiteLLM.from_model(
-    "openai/MiniMax-M2.7",
+    "openai/MiniMax-M3",
     base_url="https://api.minimax.io/v1",
 )
 

--- a/tests/test_litellm_client.py
+++ b/tests/test_litellm_client.py
@@ -524,5 +524,29 @@ class TestCompleteMessages(unittest.TestCase):
         self.assertEqual(call_kwargs["extra_headers"], {"X-Custom": "val"})
 
 
+@pytest.mark.unit
+class TestProviderDetection(unittest.TestCase):
+    """Test _get_provider_from_model provider detection."""
+
+    def test_minimax_provider_detected(self):
+        """Test that MiniMax models are detected correctly."""
+        from ace.llm_providers import LiteLLMClient
+
+        client = LiteLLMClient.__new__(LiteLLMClient)
+        self.assertEqual(client._get_provider_from_model("MiniMax-M2.5"), "minimax")
+        self.assertEqual(
+            client._get_provider_from_model("openai/MiniMax-M2.5-highspeed"),
+            "minimax",
+        )
+
+    def test_minimax_in_model_list(self):
+        """Test that MiniMax models appear in list_models."""
+        from ace.llm_providers import LiteLLMClient
+
+        models = LiteLLMClient.list_models()
+        minimax_models = [m for m in models if "MiniMax" in m]
+        self.assertGreaterEqual(len(minimax_models), 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_litellm_client.py
+++ b/tests/test_litellm_client.py
@@ -533,11 +533,12 @@ class TestProviderDetection(unittest.TestCase):
         from ace.llm_providers import LiteLLMClient
 
         client = LiteLLMClient.__new__(LiteLLMClient)
-        self.assertEqual(client._get_provider_from_model("MiniMax-M2.5"), "minimax")
+        self.assertEqual(client._get_provider_from_model("MiniMax-M2.7"), "minimax")
         self.assertEqual(
-            client._get_provider_from_model("openai/MiniMax-M2.5-highspeed"),
+            client._get_provider_from_model("openai/MiniMax-M2.7-highspeed"),
             "minimax",
         )
+        self.assertEqual(client._get_provider_from_model("MiniMax-M2.5"), "minimax")
 
     def test_minimax_in_model_list(self):
         """Test that MiniMax models appear in list_models."""
@@ -545,7 +546,15 @@ class TestProviderDetection(unittest.TestCase):
 
         models = LiteLLMClient.list_models()
         minimax_models = [m for m in models if "MiniMax" in m]
-        self.assertGreaterEqual(len(minimax_models), 2)
+        self.assertGreaterEqual(len(minimax_models), 4)
+
+    def test_minimax_m27_is_default(self):
+        """Test that MiniMax-M2.7 is the default MiniMax model."""
+        from ace.llm_providers import LiteLLMClient
+
+        models = LiteLLMClient.list_models()
+        minimax_models = [m for m in models if "MiniMax" in m]
+        self.assertEqual(minimax_models[0], "openai/MiniMax-M2.7")
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm_client.py
+++ b/tests/test_litellm_client.py
@@ -533,12 +533,12 @@ class TestProviderDetection(unittest.TestCase):
         from ace.llm_providers import LiteLLMClient
 
         client = LiteLLMClient.__new__(LiteLLMClient)
+        self.assertEqual(client._get_provider_from_model("MiniMax-M3"), "minimax")
         self.assertEqual(client._get_provider_from_model("MiniMax-M2.7"), "minimax")
         self.assertEqual(
             client._get_provider_from_model("openai/MiniMax-M2.7-highspeed"),
             "minimax",
         )
-        self.assertEqual(client._get_provider_from_model("MiniMax-M2.5"), "minimax")
 
     def test_minimax_in_model_list(self):
         """Test that MiniMax models appear in list_models."""
@@ -546,15 +546,15 @@ class TestProviderDetection(unittest.TestCase):
 
         models = LiteLLMClient.list_models()
         minimax_models = [m for m in models if "MiniMax" in m]
-        self.assertGreaterEqual(len(minimax_models), 4)
+        self.assertGreaterEqual(len(minimax_models), 3)
 
-    def test_minimax_m27_is_default(self):
-        """Test that MiniMax-M2.7 is the default MiniMax model."""
+    def test_minimax_m3_is_default(self):
+        """Test that MiniMax-M3 is the default MiniMax model."""
         from ace.llm_providers import LiteLLMClient
 
         models = LiteLLMClient.list_models()
         minimax_models = [m for m in models if "MiniMax" in m]
-        self.assertEqual(minimax_models[0], "openai/MiniMax-M2.7")
+        self.assertEqual(minimax_models[0], "openai/MiniMax-M3")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to use M3 as the default model.

## Changes
- Add `MiniMax-M3` to the model selection list and set as default
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Remove older models (M2.5/M2.5-highspeed)
- Update related unit tests and documentation

## Why
MiniMax-M3 is the latest flagship model, featuring a 512K context window, up to 128K output, and image input support.

## Testing
- Unit tests updated and passing (3 minimax-specific tests pass)
- Verified default model selection points to `openai/MiniMax-M3`