### PR TITLE
feat(cli): add kayba-pipeline skill for Claude Code

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -85,6 +85,16 @@ agent = ACELiteLLM.from_model("gpt-4o-mini")
 print(agent.ask("Hello!"))
 ```
 
+## Set Up Coding Agent Skills (Optional)
+
+If you use Claude Code, install the Kayba pipeline skill:
+
+```bash
+kayba setup
+```
+
+This installs the evaluation pipeline skill to `.claude/skills/` and prints CLI instructions. See [Hosted API](../integrations/hosted-api.md) for details.
+
 ## What to Read Next
 
 - [Setup](setup.md) — configure models and API keys

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -65,6 +65,30 @@ runner.get_strategies()                     # View learned strategies
 3. **Extract trace** — ACE reads the Claude Code execution transcript
 4. **LEARN** — Reflector analyzes the trace, SkillManager updates the skillbook
 
+## Pipeline Skill
+
+The **kayba-pipeline** skill gives Claude Code a 7-stage evaluation and improvement pipeline that can be triggered directly from the chat. Install it with:
+
+```bash
+kayba setup
+```
+
+This copies the skill into `.claude/skills/kayba-pipeline/`. The pipeline stages are:
+
+1. **Analyze traces** — extract patterns from agent execution transcripts
+2. **Compute metrics** — score traces against quality dimensions
+3. **Build rubric** — generate a structured evaluation rubric
+4. **Plan fixes** — propose concrete improvements
+5. **HITL review** — optional human-in-the-loop approval gate
+6. **Apply fixes** — execute the approved changes
+7. **Verify** — confirm fixes pass the rubric
+
+Trigger the pipeline by saying **"run the pipeline"** or **"kayba pipeline"** in Claude Code with a traces folder in your project.
+
+To skip skill installation: `kayba setup --no-skills`. See [Hosted API](hosted-api.md#agent-setup) for all `kayba setup` options.
+
+## How It Works (continued)
+
 The agent learns project-specific patterns like:
 
 - Code style and conventions

--- a/docs/integrations/hosted-api.md
+++ b/docs/integrations/hosted-api.md
@@ -166,11 +166,17 @@ Options:
 ### Agent setup
 
 ```bash
-# Print CLI instructions to stdout
+# Print CLI instructions and install pipeline skills
 kayba setup
 
 # Append to a project agent file
 kayba setup --append-to AGENTS.md
+
+# Skip skill installation
+kayba setup --no-skills
+
+# Install into a different project
+kayba setup --project-dir /path/to/project
 ```
 
 Options:
@@ -178,6 +184,10 @@ Options:
 | Flag | Description |
 |------|-------------|
 | `--append-to FILE` | Append instructions to file instead of printing (recommended: `AGENTS.md`) |
+| `--skills/--no-skills` | Install Claude Code pipeline skills (default: enabled) |
+| `--project-dir DIR` | Project root directory (default: current directory) |
+
+By default `kayba setup` copies the **kayba-pipeline** skill into `.claude/skills/`. This skill orchestrates a 7-stage evaluation pipeline (analyze traces → compute metrics → build rubric → plan fixes → HITL review → apply fixes → verify). See [Claude Code](claude-code.md#pipeline-skill) for details.
 
 ## End-to-end workflow
 
@@ -248,7 +258,8 @@ prompt = client.get_prompt(prompts[0]["id"])
 ## Coding agent setup
 
 **Quick (current session):** Tell your coding agent to run `kayba setup`. The agent will see
-the full CLI reference in its context and know how to use every command.
+the full CLI reference in its context and know how to use every command. The pipeline skill is
+also installed to `.claude/skills/`, giving Claude Code access to the 7-stage evaluation pipeline.
 
 **Persistent (all future sessions):** Append instructions to your project's agent file:
 
@@ -259,6 +270,8 @@ kayba setup --append-to .cursorrules   # Cursor only
 ```
 
 `AGENTS.md` is the recommended target — it's the universal standard supported by 20+ coding agents.
+
+To skip skill installation (e.g. for non-Claude-Code agents), pass `--no-skills`.
 
 ## Environment variables
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
     - Claude Code: integrations/claude-code.md
     - Opik Observability: integrations/opik.md
     - OpenClaw: integrations/openclaw.md
+    - Hosted API: integrations/hosted-api.md
   - API Reference: api/index.md
 
 markdown_extensions:


### PR DESCRIPTION
## Summary
- Add `kayba-pipeline` Claude Code skill with 7-stage evaluation pipeline (analyze → metrics → rubric → plan → HITL → fix → verify)
- Install skills automatically via `kayba setup` (new `--skills/--no-skills` and `--project-dir` flags)
- Document skills installation in hosted API, Claude Code, and installation docs
- Add Hosted API page to mkdocs nav

## Test plan
- [ ] `kayba setup` installs skill to `.claude/skills/kayba-pipeline/`
- [ ] `kayba setup --no-skills` skips skill installation
- [ ] mkdocs builds and all 4 updated pages render correctly
- [ ] Nav shows "Hosted API" under Integrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)