### PR TITLE
feat(pipeline): add PipelineHook protocol and CancellationToken

### DIFF
--- a/docs/PIPELINE_DESIGN.md
+++ b/docs/PIPELINE_DESIGN.md
@@ -482,6 +482,183 @@ Retry logic is the responsibility of individual steps, not the pipeline.
 
 ---
 
+## Pipeline Hooks
+
+Hooks let external code observe pipeline execution without modifying data flow. They solve a different problem than steps: steps transform data (`StepContext` in, `StepContext` out), hooks observe transitions (step started, step finished).
+
+The motivating use case is hosted/web deployments that need operational concerns — progress streaming, metrics, logging, billing — wired into the pipeline without modifying the step chain or the pipeline engine for each new concern.
+
+### Separation of concerns
+
+The pipeline has three distinct concerns, each with its own mechanism:
+
+| Concern | Mechanism | Who owns it |
+|---|---|---|
+| Data flow | Steps (`requires`/`provides`, `__call__`) | Step author |
+| Observation | Hooks (`before_step`/`after_step`) | Deployment environment |
+| Lifecycle control | `cancel_token` (see Cancellation below) | Caller |
+
+Steps own data. Hooks observe execution. Cancellation controls lifecycle. These three never overlap — a hook cannot modify context, and cancellation is not a hook.
+
+### Hook protocol
+
+```python
+@runtime_checkable
+class PipelineHook(Protocol):
+    def before_step(self, step_name: str, ctx: StepContext) -> None: ...
+    def after_step(self, step_name: str, ctx: StepContext) -> None: ...
+```
+
+**Design constraints:**
+
+- **`-> None`, not `-> StepContext`** — hooks observe, they do not transform. Context flow stays exclusively in the step chain via `requires`/`provides`. This eliminates the "second communication channel" problem — hooks cannot inject data that a later step silently depends on.
+- **`step_name: str`**, not the step object — hooks know what ran, but cannot call, inspect, or mutate the step instance. This prevents hooks from becoming an implicit dependency of step behavior.
+- **Non-blocking** — hooks must not block the event loop. They are in the hot path between steps. Heavy work (HTTP POST, disk write) should be dispatched to a background task or queue, not done inline. Same constraint as `on_sample_done`.
+- **No ordering guarantees between hooks** — hooks in the list are called sequentially in insertion order, but a hook must not depend on side effects of another hook. If ordering matters, combine them into one hook.
+- **Exception isolation** — if a hook raises, the pipeline logs the error and continues. A broken metrics hook must not kill the pipeline. Hook exceptions are never surfaced in `SampleResult`.
+
+### Pipeline integration
+
+Hooks are set at construction time — they are structural, like steps. A pipeline's observation behavior is fixed for its lifetime.
+
+```python
+class Pipeline:
+    def __init__(self, steps=None, hooks=None):
+        self._hooks = list(hooks or [])
+        ...
+```
+
+The step execution loop calls hooks around each foreground step:
+
+```python
+for step in foreground_steps:
+    step_name = type(step).__name__
+    for hook in self._hooks:
+        hook.before_step(step_name, ctx)
+    ctx = await step(ctx)
+    for hook in self._hooks:
+        hook.after_step(step_name, ctx)
+```
+
+Hooks fire for **foreground steps only**. Background steps (after `async_boundary`) do not trigger hooks — the caller has already moved on, and hook callbacks from background threads would violate the non-blocking contract. Background observability is handled via `background_stats()`.
+
+### Branch and nesting behavior
+
+- **Branch:** hooks fire once for the `Branch` step as a whole (`step_name = "Branch"`), not for each inner step of each child pipeline. Branch children are an internal implementation detail — hooks observe the outer pipeline's step sequence only. This keeps hook output predictable regardless of how many branches exist or how deep they nest.
+- **Nested Pipeline-as-Step:** same rule. The outer pipeline fires hooks for the nested pipeline step (`step_name = "MySubPipeline"`), not for its inner steps. If the nested pipeline has its own hooks, those fire independently within its own execution.
+
+### Example: progress streaming for a web app
+
+```python
+class ProgressHook:
+    """Pushes step events to an async queue for SSE streaming."""
+
+    def __init__(self, queue: asyncio.Queue):
+        self._queue = queue
+
+    def before_step(self, step_name: str, ctx: StepContext) -> None:
+        self._queue.put_nowait({"type": "step_started", "step": step_name})
+
+    def after_step(self, step_name: str, ctx: StepContext) -> None:
+        self._queue.put_nowait({"type": "step_done", "step": step_name})
+```
+
+```python
+# Web endpoint wiring (not part of pipeline/)
+queue = asyncio.Queue()
+pipe = Pipeline(steps, hooks=[ProgressHook(queue)])
+asyncio.create_task(pipe.run_async(contexts))
+# SSE endpoint reads from queue
+```
+
+The hook implementation lives in the hosted deployment code, not in `pipeline/`. The pipeline engine provides the protocol and the call sites — nothing more.
+
+---
+
+## Cancellation
+
+`cancel_token` lets a caller stop a running pipeline between steps. The motivating use case is a web app where the user clicks "Stop" and the server needs to halt processing without waiting for the remaining steps or samples to complete.
+
+### CancellationToken
+
+```python
+class CancellationToken:
+    """Thread-safe cancellation signal."""
+
+    def __init__(self) -> None:
+        self._cancelled = threading.Event()
+
+    def cancel(self) -> None:
+        """Signal cancellation. Thread-safe, idempotent."""
+        self._cancelled.set()
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self._cancelled.is_set()
+```
+
+`threading.Event` rather than `asyncio.Event` because the token must be cancellable from any thread — a web endpoint handler, a background task, a signal handler. The pipeline checks it synchronously between steps, so no async machinery is needed.
+
+### Pipeline integration
+
+`cancel_token` is passed per-invocation on `run()` and `run_async()`, not on `__init__`. A token is scoped to a single execution — each web request creates a fresh token. The pipeline object stays reusable across runs.
+
+```python
+pipe.run(contexts, cancel_token=token)
+await pipe.run_async(contexts, cancel_token=token)
+```
+
+The runner checks the token at two points:
+
+1. **Before each foreground step** — if cancelled, the current sample gets `error=PipelineCancelled()` and `failed_at` set to the step that would have run next.
+2. **Before each new sample** — if cancelled, remaining samples are not started. Samples already in-flight (via `workers > 1`) complete their current step but are cancelled before the next one.
+
+```python
+for step in foreground_steps:
+    if cancel_token is not None and cancel_token.is_cancelled:
+        result.error = PipelineCancelled()
+        result.failed_at = type(step).__name__
+        return result
+    ctx = await step(ctx)
+```
+
+### What cancellation does NOT do
+
+- **It does not interrupt a running step.** If `AgentStep` is mid-LLM-call, that call runs to completion. Cancellation is checked *between* steps, not *within* them. Steps that need intra-step cancellation (e.g. long-running browser automation) can accept the token directly and check it in their own loops — but this is a step-level concern, not a pipeline-level one.
+- **It does not cancel background steps.** Background work (after `async_boundary`) runs in separate threads and is not interrupted. `wait_for_background()` still works normally. If you need to cancel background work, shut down the step-class executors directly.
+- **It does not affect hooks.** Hooks still fire for the step that was executing when cancellation was detected — `after_step` is called, then the cancellation check runs before the *next* step.
+
+### PipelineCancelled
+
+```python
+class PipelineCancelled(Exception):
+    """Raised (internally) when a cancel_token is triggered between steps.
+
+    Surfaces in ``SampleResult.error`` — never propagated to the caller
+    of ``run()`` / ``run_async()``.  Callers check for this type to
+    distinguish cancellation from step failures.
+    """
+```
+
+`PipelineCancelled` follows the same error-handling pattern as step exceptions: it is caught per-sample and recorded in `SampleResult`, not propagated. The runner continues to the next sample (which will also be cancelled if the token is still set). This means `run()` always returns a complete list of `SampleResult` — some successful, some failed, some cancelled.
+
+### Example: web app cancel endpoint
+
+```python
+# Start a run
+token = CancellationToken()
+active_runs[run_id] = token
+task = asyncio.create_task(pipe.run_async(contexts, cancel_token=token))
+
+# Cancel endpoint
+@app.post("/runs/{run_id}/cancel")
+async def cancel_run(run_id: str):
+    active_runs[run_id].cancel()
+    return {"status": "cancelling"}
+```
+
+---
+
 ## Summary Table
 
 | Concept | Unit | Threading | Communication |
@@ -490,6 +667,8 @@ Retry logic is the responsibility of individual steps, not the pipeline.
 | `Pipeline` | ordered step list for one input | `workers=N` across inputs | via `StepContext` |
 | `Branch` | parallel pipeline list | always parallel internally | copy + merge of `StepContext` |
 | `Pipeline` as a `Step` | reuse / nesting | inherits parent context | via `StepContext` |
+| `PipelineHook` | observation point | runs in caller thread | `-> None` (read-only) |
+| `CancellationToken` | lifecycle signal | thread-safe (`threading.Event`) | checked between steps |
 
 ---
 
@@ -513,6 +692,14 @@ Four alternatives to plain set class attributes were considered:
 - Decomposed signature / Hamilton-style (steps receive named fields as parameters instead of `StepContext`): elegant zero-annotation contracts — `requires` and `provides` are inferred from function signature at zero cost. Rejected because it loses explicit ordering control (order is inferred from data dependencies, not declared; independent steps have undefined order), collapses the two-tier `StepContext`/`metadata` structure into a flat dict (integration-specific data collides with shared fields), and makes side-effect steps with no consumed output impossible to anchor in the sequence.
 
 Plain set class attributes with pipeline normalization to `frozenset` at construction time is the right balance: explicit, readable, no inheritance required, and the ordering and context model stay intact.
+
+**Alternative hook/cancellation designs:**
+Three alternatives to the observation-only `PipelineHook` + separate `cancel_token` design were considered:
+
+- Context-modifying hooks (`before_step` returns `StepContext`): hooks could transform context between steps — powerful but creates a second data-flow channel invisible to `requires`/`provides` validation. A hook could inject a field that a later step silently depends on, and the pipeline validator would not catch the dependency. Rejected to preserve the invariant that all data flow goes through the step chain.
+- Cancellation as a hook (`CancellationHook` that raises in `before_step`): keeps everything in one mechanism, but mixes observation and control. If hooks are supposed to be safe to fail (exception isolation), a cancellation hook that *must* propagate its exception breaks that contract. Rejected — cancellation is a lifecycle concern, not an observation concern, so it gets its own parameter.
+- Cancellation via `metadata` on `StepContext`: put a `CancellationToken` in `metadata` and have each step check it. Follows "behavior on the step" but couples every step to a cancellation concept, and steps that forget to check it silently ignore cancellation. Rejected — cancellation should be guaranteed by the pipeline, not opt-in per step.
+- Additional `run_async` callback parameters (no hook protocol): add `on_step_done` and `cancel_token` as parameters on `run()`/`run_async()`, following the `on_sample_done` precedent. Minimal and consistent, but each new operational concern (metrics, billing, auth context) requires adding another parameter to the pipeline's public API, which accumulates over time. The hook protocol pays a small upfront design cost to avoid this parameter growth.
 
 ---
 

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -7,28 +7,34 @@ Public surface::
         Branch,
         MergeStrategy,
         StepProtocol,
+        PipelineHook,
         StepContext,
         SampleResult,
+        CancellationToken,
         PipelineOrderError,
         PipelineConfigError,
+        PipelineCancelled,
         BranchError,
     )
 """
 
 from .branch import Branch, MergeStrategy
 from .context import StepContext
-from .errors import BranchError, PipelineConfigError, PipelineOrderError
+from .errors import BranchError, CancellationToken, PipelineCancelled, PipelineConfigError, PipelineOrderError
 from .pipeline import Pipeline
-from .protocol import SampleResult, StepProtocol
+from .protocol import PipelineHook, SampleResult, StepProtocol
 
 __all__ = [
     "Pipeline",
     "Branch",
     "MergeStrategy",
     "StepProtocol",
+    "PipelineHook",
     "StepContext",
     "SampleResult",
+    "CancellationToken",
     "PipelineOrderError",
     "PipelineConfigError",
+    "PipelineCancelled",
     "BranchError",
 ]

--- a/pipeline/errors.py
+++ b/pipeline/errors.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+
 
 class PipelineOrderError(Exception):
     """A step requires a field that no earlier step provides."""
@@ -29,3 +31,35 @@ class BranchError(Exception):
             f"{len(failures)} branch(es) failed: "
             + "; ".join(type(e).__name__ for e in failures)
         )
+
+
+class PipelineCancelled(Exception):
+    """A ``cancel_token`` was triggered between steps.
+
+    Surfaces in ``SampleResult.error`` — never propagated to the caller of
+    ``run()`` / ``run_async()``.  Callers check for this type to distinguish
+    cancellation from step failures.
+    """
+
+
+class CancellationToken:
+    """Thread-safe cancellation signal for pipeline runs.
+
+    Create a fresh token per ``run()`` / ``run_async()`` invocation.  The
+    pipeline checks ``is_cancelled`` between steps; call ``cancel()`` from
+    any thread to stop processing.
+
+    Uses ``threading.Event`` so it is safe to signal from a web endpoint
+    handler, a background task, or a signal handler.
+    """
+
+    def __init__(self) -> None:
+        self._cancelled = threading.Event()
+
+    def cancel(self) -> None:
+        """Signal cancellation.  Thread-safe, idempotent."""
+        self._cancelled.set()
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self._cancelled.is_set()

--- a/pipeline/pipeline.py
+++ b/pipeline/pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 import time
 import warnings
@@ -12,8 +13,8 @@ from typing import Any
 
 from .branch import Branch, MergeStrategy
 from .context import StepContext
-from .errors import PipelineConfigError, PipelineOrderError
-from .protocol import SampleResult
+from .errors import CancellationToken, PipelineCancelled, PipelineConfigError, PipelineOrderError
+from .protocol import PipelineHook, SampleResult
 
 
 # ---------------------------------------------------------------------------
@@ -71,14 +72,41 @@ class Pipeline:
     step inside another pipeline without extra annotation.
     """
 
-    def __init__(self, steps: list | None = None) -> None:
+    def __init__(
+        self,
+        steps: list | None = None,
+        hooks: list[PipelineHook] | None = None,
+    ) -> None:
         self._steps: list = list(steps or [])
+        self._hooks: list[PipelineHook] = list(hooks or [])
         self.requires, self.provides = self._infer_contracts(self._steps)
         self._validate_steps(self._steps)
 
         # Background thread tracking (per Pipeline instance)
         self._bg_threads: list[threading.Thread] = []
         self._bg_lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Hook helpers
+    # ------------------------------------------------------------------
+
+    def _fire_before(self, step_name: str, ctx: StepContext) -> None:
+        for hook in self._hooks:
+            try:
+                hook.before_step(step_name, ctx)
+            except Exception:
+                logging.getLogger(__name__).exception(
+                    "Hook %s.before_step raised — ignoring", type(hook).__name__
+                )
+
+    def _fire_after(self, step_name: str, ctx: StepContext) -> None:
+        for hook in self._hooks:
+            try:
+                hook.after_step(step_name, ctx)
+            except Exception:
+                logging.getLogger(__name__).exception(
+                    "Hook %s.after_step raised — ignoring", type(hook).__name__
+                )
 
     # ------------------------------------------------------------------
     # Contract inference
@@ -319,6 +347,7 @@ class Pipeline:
         contexts: Iterable[StepContext],
         workers: int = 1,
         on_sample_done: Callable[[SampleResult], None] | None = None,
+        cancel_token: CancellationToken | None = None,
     ) -> list[SampleResult]:
         """Process *contexts* through the pipeline (sync entry point).
 
@@ -341,9 +370,17 @@ class Pipeline:
             on_sample_done: Optional callback invoked after each sample
                 completes its foreground steps (or fails).  Receives the
                 ``SampleResult``.  Must not block the event loop.
+            cancel_token: Optional cancellation signal.  Checked before
+                each step and each new sample.  Pass a fresh token per
+                invocation; the pipeline object stays reusable.
         """
         return asyncio.run(
-            self.run_async(contexts, workers=workers, on_sample_done=on_sample_done)
+            self.run_async(
+                contexts,
+                workers=workers,
+                on_sample_done=on_sample_done,
+                cancel_token=cancel_token,
+            )
         )
 
     # ------------------------------------------------------------------
@@ -355,6 +392,7 @@ class Pipeline:
         contexts: Iterable[StepContext],
         workers: int = 1,
         on_sample_done: Callable[[SampleResult], None] | None = None,
+        cancel_token: CancellationToken | None = None,
     ) -> list[SampleResult]:
         """Async entry point; use ``await pipe.run_async(contexts)`` from
         coroutine contexts (e.g. inside browser-use tasks).
@@ -365,6 +403,8 @@ class Pipeline:
             on_sample_done: Optional callback invoked after each sample
                 completes its foreground steps (or fails).  Receives the
                 ``SampleResult``.  Must not block the event loop.
+            cancel_token: Optional cancellation signal.  Checked before
+                each step and each new sample.
         """
         boundary_idx = self._find_boundary_index()
         if boundary_idx is None:
@@ -384,13 +424,29 @@ class Pipeline:
                 last_step_name: str | None = None
                 try:
                     for step in foreground_steps:
-                        last_step_name = type(step).__name__
+                        step_name = type(step).__name__
+
+                        # Cancel check — before each step
+                        if cancel_token is not None and cancel_token.is_cancelled:
+                            result.error = PipelineCancelled(
+                                f"Cancelled before {step_name}"
+                            )
+                            result.failed_at = step_name
+                            if on_sample_done is not None:
+                                on_sample_done(result)
+                            return result
+
+                        last_step_name = step_name
+                        self._fire_before(step_name, ctx)
+
                         if asyncio.iscoroutinefunction(step.__call__):
                             ctx = await step(ctx)
                         elif hasattr(step, "__call_async__"):
                             ctx = await step.__call_async__(ctx)
                         else:
                             ctx = await asyncio.to_thread(step, ctx)
+
+                        self._fire_after(step_name, ctx)
                 except Exception as exc:
                     result.error = exc
                     result.failed_at = last_step_name

--- a/pipeline/protocol.py
+++ b/pipeline/protocol.py
@@ -11,6 +11,25 @@ Ctx = TypeVar("Ctx", bound=StepContext)
 
 
 @runtime_checkable
+class PipelineHook(Protocol):
+    """Observation-only hook fired around each foreground step.
+
+    Hooks observe execution — they do **not** transform data.  Both methods
+    return ``None``; context flow stays exclusively in the step chain via
+    ``requires``/``provides``.
+
+    Hooks must not block the event loop.  Heavy work (HTTP, disk) should be
+    dispatched to a background task or queue.
+
+    If a hook raises, the pipeline logs the error and continues.  A broken
+    hook must never kill the pipeline.
+    """
+
+    def before_step(self, step_name: str, ctx: StepContext) -> None: ...
+    def after_step(self, step_name: str, ctx: StepContext) -> None: ...
+
+
+@runtime_checkable
 class StepProtocol(Protocol[Ctx]):
     """Structural protocol that every step (and Pipeline/Branch) must satisfy.
 

--- a/tests/test_pipeline_hooks.py
+++ b/tests/test_pipeline_hooks.py
@@ -1,0 +1,296 @@
+"""Tests for PipelineHook and CancellationToken."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from pipeline import (
+    CancellationToken,
+    Pipeline,
+    PipelineCancelled,
+    PipelineHook,
+    SampleResult,
+    StepContext,
+)
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+class PassthroughStep:
+    requires = frozenset()
+    provides = frozenset()
+
+    def __call__(self, ctx: StepContext) -> StepContext:
+        return ctx
+
+
+class SlowStep:
+    """Step that sleeps briefly — useful for cancel-during-run tests."""
+
+    requires = frozenset()
+    provides = frozenset()
+
+    def __init__(self, delay: float = 0.1):
+        self._delay = delay
+
+    def __call__(self, ctx: StepContext) -> StepContext:
+        time.sleep(self._delay)
+        return ctx
+
+
+class FailingStep:
+    requires = frozenset()
+    provides = frozenset()
+
+    def __call__(self, ctx: StepContext) -> StepContext:
+        raise RuntimeError("boom")
+
+
+class RecordingHook:
+    """Collects (event, step_name) tuples for assertion."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str]] = []
+
+    def before_step(self, step_name: str, ctx: StepContext) -> None:
+        self.events.append(("before", step_name))
+
+    def after_step(self, step_name: str, ctx: StepContext) -> None:
+        self.events.append(("after", step_name))
+
+
+class BrokenHook:
+    """Hook that raises on every call."""
+
+    def before_step(self, step_name: str, ctx: StepContext) -> None:
+        raise ValueError("hook broken before")
+
+    def after_step(self, step_name: str, ctx: StepContext) -> None:
+        raise ValueError("hook broken after")
+
+
+# ==================================================================
+# PipelineHook tests
+# ==================================================================
+
+
+class TestPipelineHooks:
+    def test_hooks_fire_before_and_after_each_step(self):
+        hook = RecordingHook()
+        pipe = Pipeline([PassthroughStep(), PassthroughStep()], hooks=[hook])
+        pipe.run([StepContext(sample=1)])
+
+        assert hook.events == [
+            ("before", "PassthroughStep"),
+            ("after", "PassthroughStep"),
+            ("before", "PassthroughStep"),
+            ("after", "PassthroughStep"),
+        ]
+
+    def test_hooks_fire_per_sample(self):
+        hook = RecordingHook()
+        pipe = Pipeline([PassthroughStep()], hooks=[hook])
+        pipe.run([StepContext(sample=1), StepContext(sample=2)])
+
+        assert len(hook.events) == 4  # 2 samples × (before + after)
+
+    def test_multiple_hooks(self):
+        hook1 = RecordingHook()
+        hook2 = RecordingHook()
+        pipe = Pipeline([PassthroughStep()], hooks=[hook1, hook2])
+        pipe.run([StepContext(sample=1)])
+
+        assert hook1.events == [("before", "PassthroughStep"), ("after", "PassthroughStep")]
+        assert hook2.events == [("before", "PassthroughStep"), ("after", "PassthroughStep")]
+
+    def test_broken_hook_does_not_kill_pipeline(self):
+        broken = BrokenHook()
+        recorder = RecordingHook()
+        pipe = Pipeline([PassthroughStep()], hooks=[broken, recorder])
+        results = pipe.run([StepContext(sample=1)])
+
+        # Pipeline still succeeds
+        assert len(results) == 1
+        assert results[0].error is None
+        assert results[0].output is not None
+        # Second hook still fired
+        assert len(recorder.events) == 2
+
+    def test_hooks_receive_correct_step_name(self):
+        hook = RecordingHook()
+        pipe = Pipeline([SlowStep(delay=0)], hooks=[hook])
+        pipe.run([StepContext(sample=1)])
+
+        assert hook.events[0] == ("before", "SlowStep")
+        assert hook.events[1] == ("after", "SlowStep")
+
+    def test_after_hook_not_called_on_step_error(self):
+        hook = RecordingHook()
+        pipe = Pipeline([FailingStep()], hooks=[hook])
+        results = pipe.run([StepContext(sample=1)])
+
+        # before fires, step raises, after does NOT fire for that step
+        assert hook.events == [("before", "FailingStep")]
+        assert isinstance(results[0].error, RuntimeError)
+
+    def test_no_hooks_is_backward_compatible(self):
+        pipe = Pipeline([PassthroughStep()])
+        results = pipe.run([StepContext(sample=1)])
+
+        assert len(results) == 1
+        assert results[0].error is None
+
+    def test_hook_satisfies_protocol(self):
+        hook = RecordingHook()
+        assert isinstance(hook, PipelineHook)
+
+
+# ==================================================================
+# CancellationToken tests
+# ==================================================================
+
+
+class TestCancellationToken:
+    def test_not_cancelled_initially(self):
+        token = CancellationToken()
+        assert not token.is_cancelled
+
+    def test_cancel_sets_flag(self):
+        token = CancellationToken()
+        token.cancel()
+        assert token.is_cancelled
+
+    def test_cancel_is_idempotent(self):
+        token = CancellationToken()
+        token.cancel()
+        token.cancel()
+        assert token.is_cancelled
+
+    def test_cancel_is_thread_safe(self):
+        token = CancellationToken()
+
+        def cancel_from_thread():
+            time.sleep(0.01)
+            token.cancel()
+
+        t = threading.Thread(target=cancel_from_thread)
+        t.start()
+        t.join()
+        assert token.is_cancelled
+
+
+# ==================================================================
+# Pipeline cancellation tests
+# ==================================================================
+
+
+class TestPipelineCancellation:
+    def test_pre_cancelled_token_cancels_immediately(self):
+        token = CancellationToken()
+        token.cancel()
+
+        pipe = Pipeline([PassthroughStep(), PassthroughStep()])
+        results = pipe.run([StepContext(sample=1)], cancel_token=token)
+
+        assert len(results) == 1
+        assert isinstance(results[0].error, PipelineCancelled)
+        assert results[0].failed_at == "PassthroughStep"
+        assert results[0].output is None
+
+    def test_cancel_between_steps(self):
+        """Cancel after the first step; second step should not run."""
+        call_count = 0
+
+        class CountingStep:
+            requires = frozenset()
+            provides = frozenset()
+
+            def __call__(self, ctx: StepContext) -> StepContext:
+                nonlocal call_count
+                call_count += 1
+                return ctx
+
+        token = CancellationToken()
+
+        class CancelAfterFirstHook:
+            def before_step(self, step_name, ctx):
+                pass
+
+            def after_step(self, step_name, ctx):
+                # Cancel after the first step completes
+                token.cancel()
+
+        pipe = Pipeline(
+            [CountingStep(), CountingStep()],
+            hooks=[CancelAfterFirstHook()],
+        )
+        results = pipe.run([StepContext(sample=1)], cancel_token=token)
+
+        assert call_count == 1  # Only first step ran
+        assert isinstance(results[0].error, PipelineCancelled)
+
+    def test_cancel_stops_remaining_samples(self):
+        token = CancellationToken()
+        samples_started = []
+
+        class TrackingStep:
+            requires = frozenset()
+            provides = frozenset()
+
+            def __call__(self, ctx: StepContext) -> StepContext:
+                samples_started.append(ctx.sample)
+                if ctx.sample == 0:
+                    token.cancel()
+                return ctx
+
+        pipe = Pipeline([TrackingStep()])
+        results = pipe.run(
+            [StepContext(sample=i) for i in range(5)],
+            cancel_token=token,
+        )
+
+        # First sample ran (triggered cancel), rest should be cancelled
+        assert 0 in samples_started
+        cancelled = [r for r in results if isinstance(r.error, PipelineCancelled)]
+        assert len(cancelled) >= 1  # At least some were cancelled
+
+    def test_no_token_runs_normally(self):
+        pipe = Pipeline([PassthroughStep()])
+        results = pipe.run([StepContext(sample=1)], cancel_token=None)
+
+        assert len(results) == 1
+        assert results[0].error is None
+
+    def test_on_sample_done_fires_on_cancellation(self):
+        token = CancellationToken()
+        token.cancel()
+        cb_results = []
+
+        pipe = Pipeline([PassthroughStep()])
+        pipe.run(
+            [StepContext(sample=1)],
+            cancel_token=token,
+            on_sample_done=lambda r: cb_results.append(r),
+        )
+
+        assert len(cb_results) == 1
+        assert isinstance(cb_results[0].error, PipelineCancelled)
+
+    def test_cancelled_result_has_correct_shape(self):
+        token = CancellationToken()
+        token.cancel()
+
+        pipe = Pipeline([PassthroughStep()])
+        results = pipe.run([StepContext(sample="x")], cancel_token=token)
+
+        r = results[0]
+        assert r.sample == "x"
+        assert r.output is None
+        assert isinstance(r.error, PipelineCancelled)
+        assert r.failed_at is not None


### PR DESCRIPTION
## Summary
- Add observation-only `PipelineHook` protocol (`before_step`/`after_step` → `None`) for streaming progress, metrics, logging without modifying steps
- Add `CancellationToken` (thread-safe via `threading.Event`) passed per-invocation on `run()`/`run_async()` for stopping pipelines between steps
- Add `PipelineCancelled` exception surfaced in `SampleResult.error` — follows existing error handling pattern
- Hook exceptions are isolated (logged and ignored) — a broken hook never kills the pipeline
- Design doc updated with rationale, separation of concerns (data flow vs observation vs lifecycle), and rejected alternatives

## Test plan
- [x] 8 hook tests: event sequence, per-sample firing, multiple hooks, exception isolation, backward compat, protocol check
- [x] 4 cancellation token tests: initial state, cancel, idempotency, thread safety
- [x] 6 pipeline cancellation tests: pre-cancelled, cancel between steps, cancel stops remaining samples, callback fires on cancel, result shape
- [x] Full test suite: 1092 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)