### PR TITLE
feat(pipeline): add contextvar bridge and LiteLLM streaming cancellation

### DIFF
--- a/ace_next/providers/litellm.py
+++ b/ace_next/providers/litellm.py
@@ -352,8 +352,19 @@ class LiteLLMClient:
     # -- Completion methods ---------------------------------------------------
 
     def _call_completion(self, call_params: Dict[str, Any]) -> LLMResponse:
-        """Execute litellm.completion() and wrap the result."""
-        if self.router:
+        """Execute litellm.completion() and wrap the result.
+
+        When a ``cancel_token_var`` is set (by Pipeline.run_async), switches
+        to streaming mode so the token can be checked between chunks.
+        Otherwise uses the blocking API for full metadata fidelity.
+        """
+        from pipeline.errors import cancel_token_var
+
+        token = cancel_token_var.get(None)
+
+        if token is not None:
+            response = self._stream_with_cancel(call_params, token)
+        elif self.router:
             response = self.router.completion(**call_params)
         else:
             response = completion(**call_params)
@@ -362,14 +373,40 @@ class LiteLLMClient:
         metadata = {
             "model": response.model,
             "usage": response.usage.model_dump() if response.usage else None,
-            "cost": (
-                response._hidden_params.get("response_cost", None)
-                if hasattr(response, "_hidden_params")
-                else None
-            ),
+            "cost": self._compute_cost(response),
             "provider": self._get_provider_from_model(response.model),
         }
         return LLMResponse(text=text, raw=metadata)
+
+    def _stream_with_cancel(self, call_params: Dict[str, Any], token: Any) -> Any:
+        """Stream completion chunks, checking the cancel token between each.
+
+        Returns a reconstructed ``ModelResponse`` (same type as blocking
+        ``completion()``) via ``litellm.stream_chunk_builder()``.
+        """
+        from pipeline.errors import PipelineCancelled
+
+        stream_params = {**call_params, "stream": True}
+        chunks = []
+        for chunk in completion(**stream_params):
+            if token.is_cancelled:
+                raise PipelineCancelled("Cancelled during LLM call")
+            chunks.append(chunk)
+        return litellm.stream_chunk_builder(chunks)
+
+    @staticmethod
+    def _compute_cost(response: Any) -> Optional[float]:
+        """Extract cost from response, falling back to litellm computation."""
+        # Blocking path: _hidden_params is set by litellm
+        if hasattr(response, "_hidden_params"):
+            cost = response._hidden_params.get("response_cost")
+            if cost is not None:
+                return cost
+        # Streaming-rebuilt path: compute from model + usage
+        try:
+            return litellm.completion_cost(completion_response=response)
+        except Exception:
+            return None
 
     def complete(
         self, prompt: str, system: Optional[str] = None, **kwargs: Any

--- a/docs/ACE_DESIGN.md
+++ b/docs/ACE_DESIGN.md
@@ -1893,6 +1893,69 @@ trace 2:  [build_context] ──fire──► [ReflectStep] [TagStep] [UpdateSte
 
 No custom `AsyncLearningPipeline` class, no manual thread management, no `asyncio.create_task` for background learning. The pipeline engine handles all of it.
 
+### Cancellation
+
+ACE inherits cancellation support from the pipeline engine. Two levels work together:
+
+**Between steps (pipeline level):**  Pass a `CancellationToken` to `run()` / `run_async()`. The pipeline checks it before each foreground step. See `PIPELINE_DESIGN.md § Cancellation` for the full mechanism.
+
+**Within LLM calls (client level):**  `LiteLLMClient` reads `cancel_token_var` (a `contextvars.ContextVar` set by the pipeline).  When a token is present, `complete()` switches to `stream=True` internally, accumulates chunks, and checks the token between chunks.  When no token is set (standalone use, no pipeline), the blocking API is used — preserving full usage/cost metadata that is not reliably available in streaming mode across all providers.
+
+The caller sees no difference — `complete()` returns a complete `LLMResponse`, `complete_structured()` returns a validated Pydantic model.  The streaming switch is transparent.
+
+```
+Pipeline.run(contexts, cancel_token=token)
+  │
+  ├─ [check token] ← between-step (pipeline)
+  │
+  ├─ AgentStep
+  │    └─ Agent.generate()
+  │         └─ llm.complete_structured()
+  │              └─ llm.complete()       ← streaming internally
+  │                   └─ for chunk in litellm.completion(stream=True):
+  │                        [check token] ← within-step (client)
+  │
+  ├─ [check token] ← between-step (pipeline)
+  │
+  └─ ReflectStep ...
+```
+
+**How the token flows without parameter changes:**  The pipeline sets `cancel_token_var` (a `ContextVar`) before running steps. `LiteLLMClient.complete()` reads it. No changes to steps, roles, or protocols — the contextvar bridges the gap. `asyncio.to_thread()` automatically copies context variables to worker threads, so sync steps work too. See `PIPELINE_DESIGN.md § Contextvar bridge` for details.
+
+**Why conditional streaming, not streaming by default:**  The non-streaming `litellm.completion()` response includes `usage`, `_hidden_params["response_cost"]`, and other metadata that is not reliably available in streaming mode across all providers.  Always streaming would break cost tracking for every user — not just web deployments.  The conditional (`if cancel_token_var is set → stream, else → block`) preserves full metadata for standalone use while enabling intra-step cancellation when a pipeline provides a token.
+
+**Stream response reconstruction:**  When the streaming path is used, `_call_completion` collects all chunks and passes them to `litellm.stream_chunk_builder(chunks)`, which returns the **same `ModelResponse` type** as the blocking `completion()` call.  This means metadata extraction is a single code path — no duplication between streaming and blocking.  Cost is computed via a fallback chain: `response._hidden_params["response_cost"]` (set by blocking path) → `litellm.completion_cost(completion_response=response)` (works for both paths) → `None`.
+
+```python
+def _call_completion(self, call_params):
+    token = cancel_token_var.get(None)
+
+    if token is not None:
+        response = self._stream_with_cancel(call_params, token)
+    elif self.router:
+        response = self.router.completion(**call_params)
+    else:
+        response = completion(**call_params)
+
+    # ONE metadata path — identical for blocking and streaming
+    text = response.choices[0].message.content or ""
+    metadata = {
+        "model": response.model,
+        "usage": response.usage.model_dump() if response.usage else None,
+        "cost": self._compute_cost(response),
+        "provider": self._get_provider_from_model(response.model),
+    }
+    return LLMResponse(text=text, raw=metadata)
+
+def _stream_with_cancel(self, call_params, token):
+    chunks = []
+    for chunk in completion(**{**call_params, "stream": True}):
+        if token.is_cancelled:
+            raise PipelineCancelled("Cancelled during LLM call")
+        chunks.append(chunk)
+    return litellm.stream_chunk_builder(chunks)
+```
+
 ---
 
 ## Error Handling

--- a/docs/PIPELINE_DESIGN.md
+++ b/docs/PIPELINE_DESIGN.md
@@ -622,9 +622,45 @@ for step in foreground_steps:
     ctx = await step(ctx)
 ```
 
+### Contextvar bridge — making the token visible inside steps
+
+The pipeline checks the token between steps.  Code *inside* a step (e.g. an LLM client making a streaming API call) may also want to check it — but steps, roles, and LLM clients do not receive the token as a parameter.
+
+The pipeline bridges this gap with a `contextvars.ContextVar`.  Before running foreground steps, `run_async()` sets the current cancel token in the contextvar:
+
+```python
+from contextvars import ContextVar
+
+cancel_token_var: ContextVar[CancellationToken | None] = ContextVar(
+    "cancel_token_var", default=None
+)
+```
+
+```python
+# Inside Pipeline.run_async()
+_reset = cancel_token_var.set(cancel_token)
+try:
+    # ... process samples, run steps
+finally:
+    cancel_token_var.reset(_reset)
+```
+
+Any code in the call stack — a step, a role, an LLM client — can read the token without any signature changes:
+
+```python
+# Inside LiteLLMClient.complete() — no parameter changes
+token = cancel_token_var.get(None)
+if token is not None and token.is_cancelled:
+    raise PipelineCancelled("Cancelled during LLM call")
+```
+
+`asyncio.to_thread()` (used by the pipeline for sync steps) automatically copies context variables to the worker thread, so the token is visible in sync steps too.
+
+**Why a contextvar and not a parameter:**  The call chain from pipeline to LLM client crosses four layers (pipeline → step → role → client).  Threading a parameter through every layer would require changing every method signature in between — steps and roles that have no business knowing about cancellation.  A contextvar is the standard Python mechanism for request-scoped data that crosses layers without explicit plumbing.
+
 ### What cancellation does NOT do
 
-- **It does not interrupt a running step.** If `AgentStep` is mid-LLM-call, that call runs to completion. Cancellation is checked *between* steps, not *within* them. Steps that need intra-step cancellation (e.g. long-running browser automation) can accept the token directly and check it in their own loops — but this is a step-level concern, not a pipeline-level one.
+- **It does not interrupt a running step by default.** Cancellation is checked *between* steps by the pipeline.  Code inside a step can opt in to intra-step cancellation by reading `cancel_token_var` (see above) — but this is a step/client-level concern, not a pipeline-level one.
 - **It does not cancel background steps.** Background work (after `async_boundary`) runs in separate threads and is not interrupted. `wait_for_background()` still works normally. If you need to cancel background work, shut down the step-class executors directly.
 - **It does not affect hooks.** Hooks still fire for the step that was executing when cancellation was detected — `after_step` is called, then the cancellation check runs before the *next* step.
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -291,6 +291,8 @@ response = client.complete("Hello")
 
 Supports all [LiteLLM providers](https://docs.litellm.ai/) (OpenAI, Anthropic, Google, Ollama, etc.).
 
+When a `cancel_token_var` is set by the pipeline (via `run(cancel_token=...)`), `LiteLLMClient` automatically switches to streaming mode internally, checking the token between chunks for fast cancellation. Cost and usage metadata are preserved via `litellm.stream_chunk_builder()`.
+
 ### InstructorClient
 
 Wraps any LLM client with Pydantic validation for more reliable structured outputs.

--- a/docs/pipeline/api-reference.md
+++ b/docs/pipeline/api-reference.md
@@ -96,12 +96,13 @@ Ordered sequence of steps. Satisfies `StepProtocol` — can be nested inside oth
 #### Constructor
 
 ```python
-Pipeline(steps: list | None = None)
+Pipeline(steps: list | None = None, hooks: list[PipelineHook] | None = None)
 ```
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `steps` | `list \| None` | `None` | Optional initial list of steps |
+| `hooks` | `list[PipelineHook] \| None` | `None` | Observation-only hooks fired around each foreground step |
 
 Validates step ordering and infers contracts at construction time.
 
@@ -155,6 +156,8 @@ def run(
     self,
     contexts: Iterable[StepContext],
     workers: int = 1,
+    on_sample_done: Callable[[SampleResult], None] | None = None,
+    cancel_token: CancellationToken | None = None,
 ) -> list[SampleResult]
 ```
 
@@ -164,10 +167,12 @@ Process contexts through the pipeline (sync entry point).
 |-----------|------|---------|-------------|
 | `contexts` | `Iterable[StepContext]` | — | Input contexts to process |
 | `workers` | `int` | `1` | Max concurrent samples in foreground steps |
+| `on_sample_done` | `Callable \| None` | `None` | Callback after each sample's foreground steps complete (or fail). Must not block. |
+| `cancel_token` | `CancellationToken \| None` | `None` | Cancellation signal. Checked before each step and each new sample. Pass a fresh token per invocation. |
 
 **Returns:** `list[SampleResult]` — one result per input context
 
-**Notes:** Calls `asyncio.run(self.run_async(...))` internally. For background steps, call `wait_for_background()` after this returns.
+**Notes:** Calls `asyncio.run(self.run_async(...))` internally. For background steps, call `wait_for_background()` after this returns. When `cancel_token` is provided, also sets `cancel_token_var` so code inside steps (e.g. LLM clients) can read it.
 
 ---
 
@@ -178,6 +183,8 @@ async def run_async(
     self,
     contexts: Iterable[StepContext],
     workers: int = 1,
+    on_sample_done: Callable[[SampleResult], None] | None = None,
+    cancel_token: CancellationToken | None = None,
 ) -> list[SampleResult]
 ```
 
@@ -302,7 +309,79 @@ Async fan-out via `asyncio.gather`. Sync children are wrapped with `asyncio.to_t
 
 ---
 
+## `pipeline.protocol`  — Hooks
+
+### `PipelineHook`
+
+Observation-only protocol fired around each foreground step. Hooks cannot modify context — both methods return `None`.
+
+```python
+@runtime_checkable
+class PipelineHook(Protocol):
+    def before_step(self, step_name: str, ctx: StepContext) -> None: ...
+    def after_step(self, step_name: str, ctx: StepContext) -> None: ...
+```
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| `before_step` | `step_name: str, ctx: StepContext` | Called before each foreground step executes |
+| `after_step` | `step_name: str, ctx: StepContext` | Called after each foreground step completes |
+
+**Notes:**
+
+- `step_name` is `type(step).__name__` — hooks know what ran but cannot inspect or mutate the step instance
+- Hooks fire for foreground steps only — background steps (after `async_boundary`) do not trigger hooks
+- If a hook raises, the pipeline logs the error and continues — a broken hook never kills the pipeline
+- For `Branch` steps, hooks fire once for `"Branch"` as a whole, not for inner steps
+
+---
+
 ## `pipeline.errors`
+
+### `CancellationToken`
+
+Thread-safe cancellation signal. Create a fresh token per `run()` invocation.
+
+```python
+class CancellationToken:
+    def cancel(self) -> None: ...
+
+    @property
+    def is_cancelled(self) -> bool: ...
+```
+
+| Method / Property | Description |
+|-------------------|-------------|
+| `cancel()` | Signal cancellation. Thread-safe, idempotent. |
+| `is_cancelled` | `True` after `cancel()` has been called. |
+
+---
+
+### `cancel_token_var`
+
+`ContextVar` set by `Pipeline.run_async()` so code inside steps (e.g. LLM clients) can read the current cancel token without parameter changes.
+
+```python
+cancel_token_var: ContextVar[CancellationToken | None]  # default: None
+```
+
+**Notes:**
+
+- Set before steps run, reset after `run_async()` completes
+- `asyncio.to_thread()` copies contextvars automatically — visible in sync steps too
+- Read with `cancel_token_var.get(None)` — returns `None` when no pipeline is running
+
+---
+
+### `PipelineCancelled`
+
+```python
+class PipelineCancelled(Exception): ...
+```
+
+A `cancel_token` was triggered. Surfaces in `SampleResult.error` — never propagated to the caller of `run()`. Callers check `isinstance(result.error, PipelineCancelled)` to distinguish cancellation from step failures.
+
+---
 
 ### `PipelineOrderError`
 

--- a/docs/pipeline/error-handling.md
+++ b/docs/pipeline/error-handling.md
@@ -156,6 +156,28 @@ for r in results:
         print(f"Background failure at {r.failed_at}: {r.error}")
 ```
 
+### PipelineCancelled
+
+When a `cancel_token` is triggered, remaining steps and samples are cancelled with `PipelineCancelled`:
+
+```python
+from pipeline import CancellationToken, PipelineCancelled
+
+token = CancellationToken()
+# ... later, from another thread or endpoint:
+token.cancel()
+
+results = pipe.run(contexts, cancel_token=token)
+
+for r in results:
+    if isinstance(r.error, PipelineCancelled):
+        print(f"Sample '{r.sample}' was cancelled before {r.failed_at}")
+    elif r.error:
+        print(f"Sample '{r.sample}' failed at {r.failed_at}: {r.error}")
+```
+
+Cancellation is checked **between** steps — a running step always completes. `PipelineCancelled` follows the same `SampleResult` pattern as step errors: it is caught per-sample, not propagated.
+
 ### BranchError
 
 When one or more branch pipelines fail, a `BranchError` is raised with the full list of failures:

--- a/docs/pipeline/execution.md
+++ b/docs/pipeline/execution.md
@@ -32,7 +32,19 @@ Each mechanism is independent. They compose freely — you can have async steps 
     results = await pipe.run_async(contexts, workers=4)
     ```
 
+=== "With cancellation"
+
+    ```python
+    from pipeline import CancellationToken
+
+    token = CancellationToken()
+    results = pipe.run(contexts, workers=4, cancel_token=token)
+    # Call token.cancel() from another thread to stop processing
+    ```
+
 `run()` is a thin wrapper that calls `asyncio.run(self.run_async(...))`. Both accept the same parameters and return `list[SampleResult]`.
+
+Optional parameters: `on_sample_done` (callback after each sample), `cancel_token` (stop between steps). See [API Reference](api-reference.md) for full signatures.
 
 ---
 

--- a/docs/pipeline/index.md
+++ b/docs/pipeline/index.md
@@ -42,6 +42,8 @@ Steps declare what data they read and write. The pipeline validates ordering at 
 - **Immutable context** — Steps receive a frozen context and return a new one via `.replace()`, making concurrent execution safe by default
 - **Declared concurrency** — Parallelism is configured on the step (`max_workers`, `async_boundary`), not the pipeline
 - **Per-sample error isolation** — One failing sample never blocks others; every sample produces a result
+- **Observation hooks** — `PipelineHook` lets external code observe step transitions without modifying data flow (progress streaming, metrics, logging)
+- **Cancellation** — `CancellationToken` stops a running pipeline between steps; `cancel_token_var` makes the token readable inside steps for intra-step cancellation
 
 ---
 
@@ -149,7 +151,7 @@ This is critical for pipelines where early steps produce user-facing output quic
 The pipeline engine is included in the project with no extra dependencies:
 
 ```python
-from pipeline import Pipeline, Branch, StepContext, MergeStrategy
+from pipeline import Pipeline, Branch, StepContext, MergeStrategy, PipelineHook, CancellationToken
 ```
 
 !!! tip "Using the Pipeline Engine with ACE"

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -11,6 +11,7 @@ Public surface::
         StepContext,
         SampleResult,
         CancellationToken,
+        cancel_token_var,
         PipelineOrderError,
         PipelineConfigError,
         PipelineCancelled,
@@ -20,7 +21,7 @@ Public surface::
 
 from .branch import Branch, MergeStrategy
 from .context import StepContext
-from .errors import BranchError, CancellationToken, PipelineCancelled, PipelineConfigError, PipelineOrderError
+from .errors import BranchError, CancellationToken, PipelineCancelled, PipelineConfigError, PipelineOrderError, cancel_token_var
 from .pipeline import Pipeline
 from .protocol import PipelineHook, SampleResult, StepProtocol
 
@@ -33,6 +34,7 @@ __all__ = [
     "StepContext",
     "SampleResult",
     "CancellationToken",
+    "cancel_token_var",
     "PipelineOrderError",
     "PipelineConfigError",
     "PipelineCancelled",

--- a/pipeline/errors.py
+++ b/pipeline/errors.py
@@ -1,8 +1,9 @@
-"""Pipeline error types."""
+"""Pipeline error types and cancellation primitives."""
 
 from __future__ import annotations
 
 import threading
+from contextvars import ContextVar
 
 
 class PipelineOrderError(Exception):
@@ -63,3 +64,15 @@ class CancellationToken:
     @property
     def is_cancelled(self) -> bool:
         return self._cancelled.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Contextvar bridge — makes the current cancel token visible inside steps
+# without threading it through every method signature.
+# Pipeline.run_async() sets this; LLM clients read it.
+# asyncio.to_thread() copies contextvars automatically.
+# ---------------------------------------------------------------------------
+
+cancel_token_var: ContextVar[CancellationToken | None] = ContextVar(
+    "cancel_token_var", default=None
+)

--- a/pipeline/pipeline.py
+++ b/pipeline/pipeline.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from .branch import Branch, MergeStrategy
 from .context import StepContext
-from .errors import CancellationToken, PipelineCancelled, PipelineConfigError, PipelineOrderError
+from .errors import CancellationToken, PipelineCancelled, PipelineConfigError, PipelineOrderError, cancel_token_var
 from .protocol import PipelineHook, SampleResult
 
 
@@ -464,4 +464,10 @@ class Pipeline:
                     on_sample_done(result)
                 return result
 
-        return list(await asyncio.gather(*[process_one(c) for c in contexts]))
+        # Set the contextvar so code inside steps (e.g. LLM clients) can
+        # read the cancel token without explicit parameter passing.
+        _reset = cancel_token_var.set(cancel_token)
+        try:
+            return list(await asyncio.gather(*[process_one(c) for c in contexts]))
+        finally:
+            cancel_token_var.reset(_reset)

--- a/tests/test_pipeline_hooks.py
+++ b/tests/test_pipeline_hooks.py
@@ -1,4 +1,4 @@
-"""Tests for PipelineHook and CancellationToken."""
+"""Tests for PipelineHook, CancellationToken, and cancel_token_var."""
 
 from __future__ import annotations
 
@@ -14,6 +14,7 @@ from pipeline import (
     PipelineHook,
     SampleResult,
     StepContext,
+    cancel_token_var,
 )
 
 
@@ -294,3 +295,100 @@ class TestPipelineCancellation:
         assert r.output is None
         assert isinstance(r.error, PipelineCancelled)
         assert r.failed_at is not None
+
+
+# ==================================================================
+# cancel_token_var contextvar tests
+# ==================================================================
+
+
+class TestCancelTokenVar:
+    def test_contextvar_is_none_by_default(self):
+        assert cancel_token_var.get(None) is None
+
+    def test_contextvar_set_during_pipeline_run(self):
+        """Steps can read the cancel_token_var set by the pipeline."""
+        observed_tokens = []
+
+        class TokenReadingStep:
+            requires = frozenset()
+            provides = frozenset()
+
+            def __call__(self, ctx: StepContext) -> StepContext:
+                observed_tokens.append(cancel_token_var.get(None))
+                return ctx
+
+        token = CancellationToken()
+        pipe = Pipeline([TokenReadingStep()])
+        pipe.run([StepContext(sample=1)], cancel_token=token)
+
+        assert len(observed_tokens) == 1
+        assert observed_tokens[0] is token
+
+    def test_contextvar_is_none_without_cancel_token(self):
+        """When no cancel_token is passed, the contextvar is None inside steps."""
+        observed_tokens = []
+
+        class TokenReadingStep:
+            requires = frozenset()
+            provides = frozenset()
+
+            def __call__(self, ctx: StepContext) -> StepContext:
+                observed_tokens.append(cancel_token_var.get(None))
+                return ctx
+
+        pipe = Pipeline([TokenReadingStep()])
+        pipe.run([StepContext(sample=1)])
+
+        assert len(observed_tokens) == 1
+        assert observed_tokens[0] is None
+
+    def test_contextvar_reset_after_run(self):
+        """The contextvar is reset after run() completes."""
+        token = CancellationToken()
+        pipe = Pipeline([PassthroughStep()])
+        pipe.run([StepContext(sample=1)], cancel_token=token)
+
+        # After run, the contextvar should be back to default
+        assert cancel_token_var.get(None) is None
+
+    def test_contextvar_visible_across_multiple_steps(self):
+        """All steps in the same pipeline run see the same token."""
+        observed_tokens = []
+
+        class TokenReadingStep:
+            requires = frozenset()
+            provides = frozenset()
+
+            def __call__(self, ctx: StepContext) -> StepContext:
+                observed_tokens.append(cancel_token_var.get(None))
+                return ctx
+
+        token = CancellationToken()
+        pipe = Pipeline([TokenReadingStep(), TokenReadingStep(), TokenReadingStep()])
+        pipe.run([StepContext(sample=1)], cancel_token=token)
+
+        assert len(observed_tokens) == 3
+        assert all(t is token for t in observed_tokens)
+
+    def test_contextvar_per_sample(self):
+        """Each sample in the same run sees the same token."""
+        observed_tokens = []
+
+        class TokenReadingStep:
+            requires = frozenset()
+            provides = frozenset()
+
+            def __call__(self, ctx: StepContext) -> StepContext:
+                observed_tokens.append(cancel_token_var.get(None))
+                return ctx
+
+        token = CancellationToken()
+        pipe = Pipeline([TokenReadingStep()])
+        pipe.run(
+            [StepContext(sample=i) for i in range(3)],
+            cancel_token=token,
+        )
+
+        assert len(observed_tokens) == 3
+        assert all(t is token for t in observed_tokens)


### PR DESCRIPTION
## Summary
- Add `cancel_token_var` (ContextVar) to pipeline — set in `run_async()`, readable by any code in the call stack without parameter changes
- `LiteLLMClient._call_completion()` reads the contextvar; switches to `stream=True` when a token is present, checking between chunks for fast intra-step cancellation
- Stream response reconstructed via `litellm.stream_chunk_builder()` — same `ModelResponse` type, single metadata extraction path
- Cost fallback chain: `_hidden_params["response_cost"]` → `litellm.completion_cost()` → `None`
- All pipeline and ACE docs updated (api-reference, error-handling, execution, index, ACE_DESIGN, PIPELINE_DESIGN)

Builds on #106 (PipelineHook + CancellationToken).

## Test plan
- [x] 6 contextvar tests: token visible in steps, None without token, reset after run, visible across steps/samples
- [x] All 24 hook/cancellation tests pass
- [x] Full suite: 1098 passed, 0 failed
