### PR TITLE
feat(pipeline): contextvar bridge and cancellation token support

### DIFF
--- a/ace_next/runners/base.py
+++ b/ace_next/runners/base.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable, Sequence
 from typing import Any
 
 from pipeline import Pipeline
+from pipeline.errors import CancellationToken
 from pipeline.protocol import SampleResult
 
 from ..core.context import ACEStepContext, SkillbookView
@@ -88,12 +89,18 @@ class ACERunner:
         *,
         epochs: int,
         wait: bool = True,
+        cancel_token: CancellationToken | None = None,
         **kwargs: Any,
     ) -> list[SampleResult]:
         """Generic run loop handling epochs and Iterable validation.
 
         Returns when ``wait=True`` (default).  Returns after foreground
         steps when ``wait=False`` — background learning continues.
+
+        Args:
+            cancel_token: Optional cancellation signal.  Forwarded to
+                ``Pipeline.run()`` — checked between steps and inside
+                LLM calls (via contextvar).
 
         Raises ``ValueError`` if ``epochs > 1`` and *items* is not a
         ``Sequence``.
@@ -107,6 +114,8 @@ class ACERunner:
         n: int | None = len(items) if isinstance(items, Sequence) else None
 
         for epoch in range(1, epochs + 1):
+            if cancel_token is not None and cancel_token.is_cancelled:
+                break
             logger.info(
                 "Epoch %d/%d: processing %s samples",
                 epoch,
@@ -127,7 +136,9 @@ class ACERunner:
                 )
                 for idx, item in enumerate(items, start=1)
             ]
-            epoch_results = self.pipeline.run(contexts)
+            epoch_results = self.pipeline.run(
+                contexts, cancel_token=cancel_token
+            )
             results.extend(epoch_results)
 
         if wait:

--- a/ace_next/runners/trace_analyser.py
+++ b/ace_next/runners/trace_analyser.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from pipeline import Pipeline
+from pipeline.errors import CancellationToken
 from pipeline.protocol import SampleResult, StepProtocol
 
 from ..core.context import ACEStepContext, SkillbookView
@@ -131,6 +132,7 @@ class TraceAnalyser(ACERunner):
         epochs: int = 1,
         *,
         wait: bool = True,
+        cancel_token: CancellationToken | None = None,
     ) -> list[SampleResult]:
         """Analyse traces and evolve the skillbook.
 
@@ -138,11 +140,14 @@ class TraceAnalyser(ACERunner):
             traces: Sequence of raw trace objects (any type).
             epochs: Number of passes over all traces.
             wait: If ``True``, block until background learning completes.
+            cancel_token: Optional cancellation signal.  Forwarded to
+                ``Pipeline.run()`` — checked between steps and inside
+                LLM calls (via contextvar).
 
         Returns:
             List of ``SampleResult``, one per trace per epoch.
         """
-        return self._run(traces, epochs=epochs, wait=wait)
+        return self._run(traces, epochs=epochs, wait=wait, cancel_token=cancel_token)
 
     def _build_context(  # type: ignore[override]
         self,


### PR DESCRIPTION
## Summary
- Add contextvar bridge so `CancellationToken` is available inside LiteLLM streaming callbacks, enabling mid-stream cancellation
- Thread `CancellationToken` through `ACERunner._run()` and `TraceAnalyser.analyse()` so callers can signal cancellation across epochs and pipeline steps
- Update pipeline engine to check cancellation between steps

## Test plan
- [x] Existing `test_pipeline_hooks.py` extended with cancellation scenarios
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)