### PR TITLE
feat(integrations): add Claude SDK step

### DIFF
--- a/ace/integrations/__init__.py
+++ b/ace/integrations/__init__.py
@@ -26,6 +26,7 @@ from ..implementations.prompts import wrap_skillbook_for_external_agent
 
 from .browser_use import BrowserExecuteStep, BrowserResult, BrowserToTrace
 from .claude_code import ClaudeCodeExecuteStep, ClaudeCodeResult, ClaudeCodeToTrace
+from .claude_sdk import ClaudeSDKExecuteStep, ClaudeSDKResult, ClaudeSDKToTrace, ToolCall
 from .langchain import LangChainExecuteStep, LangChainResult, LangChainToTrace
 from .openclaw import OpenClawToTraceStep
 
@@ -48,6 +49,11 @@ __all__ = [
     "ClaudeCodeExecuteStep",
     "ClaudeCodeResult",
     "ClaudeCodeToTrace",
+    # Claude SDK
+    "ClaudeSDKExecuteStep",
+    "ClaudeSDKResult",
+    "ClaudeSDKToTrace",
+    "ToolCall",
     # LangChain
     "LangChainExecuteStep",
     "LangChainResult",

--- a/ace/integrations/claude_sdk.py
+++ b/ace/integrations/claude_sdk.py
@@ -1,0 +1,525 @@
+"""Claude SDK integration — execute step, result type, and trace converter.
+
+Uses the ``anthropic`` Python SDK directly for full API access with
+built-in observability (token tracking, latency, Logfire spans and
+auto-instrumentation).
+
+Usage::
+
+    from ace.integrations import ClaudeSDKExecuteStep, ClaudeSDKToTrace
+    from ace.steps import learning_tail
+
+    steps = [
+        ClaudeSDKExecuteStep(model="claude-sonnet-4-20250514"),
+        ClaudeSDKToTrace(),
+        *learning_tail(reflector, skill_manager, skillbook),
+    ]
+    pipeline = Pipeline(steps)
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from ..core.context import ACEStepContext
+from ..implementations.prompts import wrap_skillbook_for_external_agent
+
+logger = logging.getLogger(__name__)
+
+
+def _get_logfire() -> Any:
+    """Return the ``logfire`` module if configured, else ``None``."""
+    try:
+        from ace.observability import is_configured
+
+        if is_configured():
+            import logfire
+
+            return logfire
+    except Exception:
+        pass
+    return None
+
+
+@contextmanager
+def _logfire_span(name: str, **attributes: Any) -> Iterator[Any]:
+    """Open a Logfire span if configured, otherwise yield a no-op object.
+
+    Attributes can be set on the yielded object via ``set_attribute``.
+    When Logfire is not active the context manager yields a lightweight
+    stub so callers don't need conditional logic.
+    """
+    lf = _get_logfire()
+    if lf is not None:
+        with lf.span(name, **attributes) as span:
+            yield span
+    else:
+        yield _NoOpSpan()
+
+
+class _NoOpSpan:
+    """Stub returned when Logfire is not configured."""
+
+    def set_attribute(self, key: str, value: Any) -> None:  # noqa: ARG002
+        pass
+
+    def record_exception(self, exc: BaseException) -> None:  # noqa: ARG002
+        pass
+
+
+try:
+    import anthropic
+
+    ANTHROPIC_SDK_AVAILABLE = True
+except ImportError:
+    ANTHROPIC_SDK_AVAILABLE = False
+    anthropic = None  # type: ignore[misc,assignment]
+
+
+# ---------------------------------------------------------------------------
+# Input / Output types
+# ---------------------------------------------------------------------------
+
+
+class ToolCall(BaseModel):
+    """A single tool call from the Claude API response."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(..., description="Tool call ID (e.g. toolu_01...)")
+    name: str = Field(..., description="Tool name")
+    input: Dict[str, Any] = Field(
+        default_factory=dict, description="Tool input arguments"
+    )
+
+
+class _ClaudeSDKConfig(BaseModel):
+    """Validated configuration for :class:`ClaudeSDKExecuteStep`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    model: str = Field(default="claude-sonnet-4-20250514", min_length=1)
+    system_prompt: Optional[str] = None
+    max_tokens: int = Field(default=4096, gt=0)
+    temperature: float = Field(default=0.0, ge=0.0, le=1.0)
+    tools: Optional[List[Dict[str, Any]]] = None
+    api_key: Optional[str] = None
+    base_url: Optional[str] = None
+    inject_skillbook: bool = True
+
+
+class ClaudeSDKResult(BaseModel):
+    """Output from a direct Anthropic SDK call.
+
+    This is the integration-specific result — not yet in ACE trace format.
+    Use ``ClaudeSDKToTrace`` to convert to a standardised trace dict.
+
+    Includes validated observability data: token usage, latency, model info.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+    task: str = Field(..., description="Original task/question sent to the API")
+    success: bool = Field(..., description="Whether the API call succeeded")
+    output: str = Field(default="", description="Text output from the model")
+    error: Optional[str] = Field(
+        default=None, description="Error message if the call failed"
+    )
+    model: str = Field(default="", description="Model ID used for the request")
+    stop_reason: Optional[str] = Field(
+        default=None,
+        description="Why the model stopped: end_turn, max_tokens, tool_use, etc.",
+    )
+    # Observability — token usage
+    input_tokens: int = Field(default=0, ge=0, description="Prompt tokens consumed")
+    output_tokens: int = Field(
+        default=0, ge=0, description="Completion tokens generated"
+    )
+    total_tokens: int = Field(default=0, ge=0, description="Total tokens (in + out)")
+    # Observability — latency
+    latency_seconds: float = Field(
+        default=0.0, ge=0.0, description="Wall-clock time for the API call"
+    )
+    # Tool use tracking
+    tool_calls: List[ToolCall] = Field(
+        default_factory=list, description="Tool calls made by the model"
+    )
+    cited_skill_ids: List[str] = Field(
+        default_factory=list,
+        description="Skill IDs cited in the output ([section-00001] patterns)",
+    )
+    # Raw response for full access
+    raw_response: Any = Field(
+        default=None,
+        exclude=True,
+        description="Raw Anthropic API response object",
+    )
+
+    @model_validator(mode="after")
+    def _compute_total(self) -> "ClaudeSDKResult":
+        """Auto-compute total_tokens from input + output if left at default."""
+        if self.total_tokens == 0 and (self.input_tokens or self.output_tokens):
+            self.total_tokens = self.input_tokens + self.output_tokens
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Execute step
+# ---------------------------------------------------------------------------
+
+
+class ClaudeSDKExecuteStep:
+    """INJECT skillbook context and EXECUTE via the Anthropic Python SDK.
+
+    Reads a task/question from ``ctx.sample``, calls the Claude Messages
+    API directly, and writes a ``ClaudeSDKResult`` to ``ctx.trace``.
+
+    Observability is built in:
+
+    - **Logfire spans** with structured attributes (model, tokens,
+      latency, stop_reason, tool_count) when Logfire is configured
+    - **Logfire auto-instrumentation** of the underlying Anthropic
+      client (child spans for each API call)
+    - **Token usage** (input/output/total) from the API response
+    - **Latency** (wall-clock time for the API call)
+    - **Structured logging** of per-call metrics (always active)
+
+    Compose with the learning tail::
+
+        steps = [
+            ClaudeSDKExecuteStep(model="claude-sonnet-4-20250514"),
+            ClaudeSDKToTrace(),
+            *learning_tail(reflector, skill_manager, skillbook),
+        ]
+    """
+
+    requires = frozenset({"sample", "skillbook"})
+    provides = frozenset({"trace"})
+
+    def __init__(
+        self,
+        model: str = "claude-sonnet-4-20250514",
+        *,
+        system_prompt: Optional[str] = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.0,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        inject_skillbook: bool = True,
+        client: Any = None,
+        **client_kwargs: Any,
+    ) -> None:
+        config = _ClaudeSDKConfig(
+            model=model,
+            system_prompt=system_prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            tools=tools,
+            api_key=api_key,
+            base_url=base_url,
+            inject_skillbook=inject_skillbook,
+        )
+        self.model = config.model
+        self.system_prompt = config.system_prompt
+        self.max_tokens = config.max_tokens
+        self.temperature = config.temperature
+        self.tools = config.tools
+        self.inject_skillbook = config.inject_skillbook
+
+        if client is not None:
+            self._client = client
+        elif ANTHROPIC_SDK_AVAILABLE:
+            ckw: Dict[str, Any] = {**client_kwargs}
+            if config.api_key is not None:
+                ckw["api_key"] = config.api_key
+            if config.base_url is not None:
+                ckw["base_url"] = config.base_url
+            self._client = anthropic.Anthropic(**ckw)
+        else:
+            raise ImportError(
+                "anthropic SDK not installed. Install with: uv add "
+                '"ace-framework[claude-sdk]" or uv add anthropic'
+            )
+
+        self._try_instrument()
+
+    # ------------------------------------------------------------------
+    # Logfire auto-instrumentation
+    # ------------------------------------------------------------------
+
+    def _try_instrument(self) -> None:
+        """Auto-instrument the Anthropic client with Logfire if configured.
+
+        Logfire instruments the client eagerly and returns an optional context
+        manager for later uninstrumentation. The instrumentation call itself is
+        sufficient here.
+        """
+        try:
+            from ace.observability import is_configured
+
+            if is_configured():
+                import logfire
+
+                logfire.instrument_anthropic(self._client)
+                logger.debug("ClaudeSDKExecuteStep: Logfire instrumentation active")
+        except Exception as exc:
+            logger.debug("Logfire instrumentation skipped: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Step execution
+    # ------------------------------------------------------------------
+
+    def __call__(self, ctx: ACEStepContext) -> ACEStepContext:
+        task = self._extract_task(ctx.sample)
+        system = self._build_system(ctx.skillbook)
+        messages: List[Dict[str, Any]] = [{"role": "user", "content": task}]
+
+        with _logfire_span(
+            "ClaudeSDKExecuteStep",
+            model=self.model,
+            task=task[:200],
+            has_system=system is not None,
+            has_tools=bool(self.tools),
+        ) as span:
+            result = self._execute(task, system, messages)
+            span.set_attribute("success", result.success)
+            span.set_attribute("input_tokens", result.input_tokens)
+            span.set_attribute("output_tokens", result.output_tokens)
+            span.set_attribute("total_tokens", result.total_tokens)
+            span.set_attribute("latency_seconds", result.latency_seconds)
+            span.set_attribute("stop_reason", result.stop_reason or "")
+            span.set_attribute("tool_call_count", len(result.tool_calls))
+            span.set_attribute("cited_skill_count", len(result.cited_skill_ids))
+            if result.error:
+                span.set_attribute("error", result.error)
+
+        return ctx.replace(trace=result)
+
+    # ------------------------------------------------------------------
+    # Task extraction
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_task(sample: Any) -> str:
+        """Extract task string from sample (string or ACESample)."""
+        if isinstance(sample, str):
+            return sample
+        if hasattr(sample, "question"):
+            parts = [sample.question]
+            if hasattr(sample, "context") and sample.context:
+                parts.append(f"\nContext: {sample.context}")
+            return "\n".join(parts)
+        return str(sample)
+
+    # ------------------------------------------------------------------
+    # System prompt with skillbook injection
+    # ------------------------------------------------------------------
+
+    def _build_system(self, skillbook: Any) -> Optional[str]:
+        """Build the system prompt, optionally injecting skillbook context."""
+        parts: List[str] = []
+        if self.system_prompt:
+            parts.append(self.system_prompt)
+        if self.inject_skillbook and skillbook is not None:
+            context = wrap_skillbook_for_external_agent(skillbook)
+            if context:
+                parts.append(context)
+        return "\n\n".join(parts) if parts else None
+
+    # ------------------------------------------------------------------
+    # API call
+    # ------------------------------------------------------------------
+
+    def _execute(
+        self,
+        task: str,
+        system: Optional[str],
+        messages: List[Dict[str, Any]],
+    ) -> ClaudeSDKResult:
+        """Call the Anthropic Messages API and build a result with metrics."""
+        api_kwargs: Dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": self.max_tokens,
+            "temperature": self.temperature,
+            "messages": messages,
+        }
+        if system is not None:
+            api_kwargs["system"] = system
+        if self.tools:
+            api_kwargs["tools"] = self.tools
+
+        start = time.monotonic()
+        try:
+            response = self._client.messages.create(**api_kwargs)
+            latency = time.monotonic() - start
+
+            text_parts: List[str] = []
+            tool_calls: List[ToolCall] = []
+            for block in response.content:
+                if block.type == "text":
+                    text_parts.append(block.text)
+                elif block.type == "tool_use":
+                    tool_calls.append(
+                        ToolCall(
+                            id=block.id,
+                            name=block.name,
+                            input=block.input or {},
+                        )
+                    )
+
+            output = "\n".join(text_parts)
+            cited_ids = self._extract_skill_ids(output)
+
+            result = ClaudeSDKResult(
+                task=task,
+                success=True,
+                output=output,
+                model=response.model,
+                stop_reason=response.stop_reason,
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+                total_tokens=(
+                    response.usage.input_tokens + response.usage.output_tokens
+                ),
+                latency_seconds=round(latency, 3),
+                tool_calls=tool_calls,
+                cited_skill_ids=cited_ids,
+                raw_response=response,
+            )
+            self._log_metrics(result)
+            return result
+
+        except Exception as exc:
+            latency = time.monotonic() - start
+            logger.error(
+                "ClaudeSDKExecuteStep failed after %.2fs: %s",
+                latency,
+                exc,
+            )
+            lf = _get_logfire()
+            if lf is not None:
+                lf.error(
+                    "ClaudeSDK call failed",
+                    error=str(exc),
+                    model=self.model,
+                    latency_seconds=round(latency, 3),
+                )
+            return ClaudeSDKResult(
+                task=task,
+                success=False,
+                error=str(exc),
+                model=self.model,
+                latency_seconds=round(latency, 3),
+            )
+
+    # ------------------------------------------------------------------
+    # Observability helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _log_metrics(result: ClaudeSDKResult) -> None:
+        """Log structured observability metrics via logging and Logfire."""
+        logger.info(
+            "ClaudeSDK: model=%s tokens=%d/%d/%d latency=%.2fs stop=%s tools=%d",
+            result.model,
+            result.input_tokens,
+            result.output_tokens,
+            result.total_tokens,
+            result.latency_seconds,
+            result.stop_reason,
+            len(result.tool_calls),
+        )
+        lf = _get_logfire()
+        if lf is not None:
+            lf.info(
+                "ClaudeSDK call completed",
+                model=result.model,
+                input_tokens=result.input_tokens,
+                output_tokens=result.output_tokens,
+                total_tokens=result.total_tokens,
+                latency_seconds=result.latency_seconds,
+                stop_reason=result.stop_reason,
+                tool_call_count=len(result.tool_calls),
+            )
+
+    @staticmethod
+    def _extract_skill_ids(text: str) -> List[str]:
+        """Extract cited skill IDs from output text."""
+        try:
+            from ..implementations.helpers import extract_cited_skill_ids
+
+            return extract_cited_skill_ids(text)
+        except Exception:
+            return []
+
+
+# ---------------------------------------------------------------------------
+# Convert step — ClaudeSDKResult → standardised trace dict
+# ---------------------------------------------------------------------------
+
+
+class ClaudeSDKToTrace:
+    """Convert a ``ClaudeSDKResult`` on ``ctx.trace`` to the standardised
+    trace dict that the learning tail (``ReflectStep``) expects.
+
+    Includes observability metadata (tokens, latency) in reasoning and
+    feedback for the reflector to consider.
+    """
+
+    requires = frozenset({"trace"})
+    provides = frozenset({"trace"})
+
+    def __call__(self, ctx: ACEStepContext) -> ACEStepContext:
+        r: ClaudeSDKResult = ctx.trace  # type: ignore[assignment]
+
+        parts: List[str] = []
+        status = "succeeded" if r.success else "failed"
+        parts.append(f"Claude SDK call {status} ({r.model})")
+        parts.append(
+            f"Tokens: {r.input_tokens} in / {r.output_tokens} out / "
+            f"{r.total_tokens} total"
+        )
+        parts.append(f"Latency: {r.latency_seconds}s")
+        if r.stop_reason:
+            parts.append(f"Stop reason: {r.stop_reason}")
+        if r.tool_calls:
+            parts.append(f"\nTool calls ({len(r.tool_calls)}):")
+            for tc in r.tool_calls:
+                parts.append(f"  - {tc.name}({tc.input})")
+        if r.output:
+            parts.append(f"\nOutput:\n{r.output}")
+        if r.error:
+            parts.append(f"\nError: {r.error}")
+        reasoning = "\n".join(parts)
+
+        feedback = f"Claude SDK call {status}"
+        if r.error:
+            feedback += f"\nError: {r.error}"
+        feedback += (
+            f"\nTokens: {r.input_tokens}+{r.output_tokens}={r.total_tokens}"
+            f" | Latency: {r.latency_seconds}s"
+        )
+
+        trace: dict = {
+            "question": r.task,
+            "reasoning": reasoning,
+            "answer": r.output,
+            "skill_ids": r.cited_skill_ids,
+            "feedback": feedback,
+            "ground_truth": None,
+        }
+        return ctx.replace(trace=trace)
+
+
+__all__ = [
+    "ClaudeSDKExecuteStep",
+    "ClaudeSDKResult",
+    "ClaudeSDKToTrace",
+    "ToolCall",
+]

--- a/docs/ACE_DESIGN.md
+++ b/docs/ACE_DESIGN.md
@@ -19,7 +19,7 @@ Architecture for the ACE pipeline-based framework. Roles are backed by PydanticA
 | `ACE` runner | Done | `ace/runners/ace.py` |
 | Implementations (`Agent`, `Reflector`, `SkillManager`) — PydanticAI-backed | Done | `ace/implementations/` |
 | Deduplication (`DeduplicationManager`, `SimilarityDetector`) | Done | `ace/deduplication/` |
-| Integration steps (`BrowserExecuteStep`, `LangChainExecuteStep`, `ClaudeCodeExecuteStep`) | Done | `ace/integrations/` |
+| Integration steps (`BrowserExecuteStep`, `LangChainExecuteStep`, `ClaudeCodeExecuteStep`, `ClaudeSDKExecuteStep`) | Done | `ace/integrations/` |
 | Integration runners (`BrowserUse`, `LangChain`, `ClaudeCode`) | Done | `ace/runners/` |
 | Convenience `from_model()` on integration runners | Done | `ace/runners/browser_use.py`, `langchain.py`, `claude_code.py` |
 | `ACELiteLLM` convenience wrapper | Done | `ace/runners/litellm.py` |
@@ -727,6 +727,7 @@ Integration steps live in `ace.integrations` (they have framework-specific depen
 from ace.integrations.browser_use import BrowserExecuteStep, BrowserToTrace
 from ace.integrations.langchain import LangChainExecuteStep, LangChainToTrace
 from ace.integrations.claude_code import ClaudeCodeExecuteStep, ClaudeCodeToTrace
+from ace.integrations.claude_sdk import ClaudeSDKExecuteStep, ClaudeSDKToTrace
 from ace.integrations.openclaw import OpenClawToTraceStep
 ```
 
@@ -1230,7 +1231,7 @@ ace = ACE.from_roles(
 
 ## Integration Pattern
 
-External frameworks (browser-use, LangChain, Claude Code) integrate via composable pipeline steps in `ace/integrations/`. Each integration provides three things:
+External frameworks (browser-use, LangChain, Claude Code, Anthropic SDK) integrate via composable pipeline steps in `ace/integrations/`. Each integration provides three things:
 
 1. **Result type** — an integration-specific dataclass (e.g. `BrowserResult`, `ClaudeCodeResult`)
 2. **Execute step** — INJECT skillbook context + EXECUTE the framework, writes the result to `ctx.trace`
@@ -1319,6 +1320,7 @@ Each integration defines its own result dataclass:
 |---|---|---|
 | Browser-use | `BrowserResult` | `task`, `success`, `output`, `error`, `steps_count`, `duration_seconds`, `cited_skill_ids`, `chronological_steps`, `raw_history` |
 | Claude Code | `ClaudeCodeResult` | `task`, `success`, `output`, `execution_trace`, `returncode`, `error` |
+| Claude SDK | `ClaudeSDKResult` | `task`, `success`, `output`, `error`, `model`, `stop_reason`, `input_tokens`, `output_tokens`, `total_tokens`, `latency_seconds`, `tool_calls`, `cited_skill_ids`, `raw_response` |
 | LangChain | `LangChainResult` | `task`, `output`, `result_type` (simple/agent/langgraph/error), `success`, `error`, `intermediate_steps`, `messages`, `raw_result` |
 
 ### Example — browser-use execute step
@@ -1679,6 +1681,7 @@ ace/
     browser_use.py            ← BrowserExecuteStep, BrowserResult, BrowserToTrace
     langchain.py              ← LangChainExecuteStep, LangChainResult, LangChainToTrace
     claude_code.py            ← ClaudeCodeExecuteStep, ClaudeCodeResult, ClaudeCodeToTrace
+    claude_sdk.py             ← ClaudeSDKExecuteStep, ClaudeSDKResult, ClaudeSDKToTrace
     openclaw/
       __init__.py             ← Exports OpenClawToTraceStep
       to_trace.py             ← OpenClawToTraceStep (JSONL events → structured trace dict)

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -95,6 +95,28 @@ results = runner.run("Add unit tests for utils.py")
 
 See [Claude Code Integration](../integrations/claude-code.md).
 
+### ClaudeSDKExecuteStep / ClaudeSDKToTrace
+
+Direct Anthropic Messages API steps for custom pipelines.
+
+```python
+from ace import Pipeline, Reflector, SkillManager, Skillbook, learning_tail
+from ace.integrations import ClaudeSDKExecuteStep, ClaudeSDKToTrace
+
+skillbook = Skillbook()
+pipe = Pipeline([
+    ClaudeSDKExecuteStep(model="claude-sonnet-4-20250514"),
+    ClaudeSDKToTrace(),
+    *learning_tail(Reflector("gpt-4o-mini"), SkillManager("gpt-4o-mini"), skillbook),
+])
+```
+
+`ClaudeSDKResult` and `ToolCall` are Pydantic models, so token counts, latency,
+tool calls, and serialization are validated before the learning tail consumes
+the trace.
+
+See [Claude SDK Integration](../integrations/claude-sdk.md).
+
 ---
 
 ## Roles

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -16,6 +16,7 @@
     uv add ace-framework[langchain]      # LangChain integration
     uv add ace-framework[browser-use]    # Browser automation
     uv add ace-framework[claude-code]    # Claude Code CLI integration
+    uv add ace-framework[claude-sdk]     # Anthropic SDK integration steps
     uv add ace-framework[observability]  # Opik monitoring + cost tracking
     uv add ace-framework[deduplication]  # Skill deduplication (embeddings)
     uv add ace-framework[transformers]   # Local model support

--- a/docs/guides/composing-pipelines.md
+++ b/docs/guides/composing-pipelines.md
@@ -283,4 +283,5 @@ Integration steps (in `ace.integrations`):
 | `BrowserExecuteStep` / `BrowserToTrace` | browser-use |
 | `LangChainExecuteStep` / `LangChainToTrace` | LangChain |
 | `ClaudeCodeExecuteStep` / `ClaudeCodeToTrace` | Claude Code |
+| `ClaudeSDKExecuteStep` / `ClaudeSDKToTrace` | Anthropic Python SDK |
 | `OpenClawToTraceStep` | OpenClaw |

--- a/docs/guides/integration.md
+++ b/docs/guides/integration.md
@@ -1,6 +1,8 @@
 # Integration Pattern
 
-Use the integration pattern when you have an **existing agent** (browser-use, LangChain, Claude Code, or a custom framework) and want to add ACE learning on top.
+Use the integration pattern when you have an **existing agent** (browser-use,
+LangChain, Claude Code, the Anthropic SDK, or a custom framework) and want to
+add ACE learning on top.
 
 !!! note "Full Pipeline vs Integration"
     The [Full Pipeline](full-pipeline.md) uses all three ACE roles. The integration pattern skips the ACE Agent — your external agent handles execution, and ACE only learns from the results.
@@ -52,6 +54,24 @@ ACE provides runners for popular frameworks. Each uses `from_model()` for quick 
     results = runner.run(["Add tests for utils.py", "Fix the login bug"])
     runner.save("code_expert.json")
     ```
+
+## Direct SDK Steps
+
+The Anthropic SDK integration is step-based rather than runner-based. Use it
+when you want direct Messages API access, tool use, validated result models,
+and Logfire observability inside your own pipeline:
+
+```python
+from ace import Pipeline, Reflector, SkillManager, Skillbook, learning_tail
+from ace.integrations import ClaudeSDKExecuteStep, ClaudeSDKToTrace
+
+skillbook = Skillbook()
+pipe = Pipeline([
+    ClaudeSDKExecuteStep(model="claude-sonnet-4-20250514"),
+    ClaudeSDKToTrace(),
+    *learning_tail(Reflector("gpt-4o-mini"), SkillManager("gpt-4o-mini"), skillbook),
+])
+```
 
 ## Construction Patterns
 
@@ -149,3 +169,4 @@ See [Pipeline Engine: Building Custom Steps](../pipeline/custom-steps.md) for th
 - [Browser-Use Integration](../integrations/browser-use.md) — browser automation details
 - [LangChain Integration](../integrations/langchain.md) — chain/agent wrapping
 - [Claude Code Integration](../integrations/claude-code.md) — coding tasks
+- [Claude SDK Integration](../integrations/claude-sdk.md) — direct Anthropic API steps

--- a/docs/integrations/claude-sdk.md
+++ b/docs/integrations/claude-sdk.md
@@ -1,0 +1,121 @@
+# Claude SDK Integration
+
+The Claude SDK integration provides composable ACE steps for the
+[Anthropic Python SDK](https://docs.anthropic.com/en/api/client-sdks). Use it
+when you want direct Messages API access inside your own pipeline instead of a
+prebuilt runner.
+
+## Quick Start
+
+```python
+from ace import Pipeline, Reflector, SkillManager, Skillbook, learning_tail
+from ace.integrations import ClaudeSDKExecuteStep, ClaudeSDKToTrace
+
+skillbook = Skillbook()
+pipe = Pipeline([
+    ClaudeSDKExecuteStep(model="claude-sonnet-4-20250514"),
+    ClaudeSDKToTrace(),
+    *learning_tail(Reflector("gpt-4o-mini"), SkillManager("gpt-4o-mini"), skillbook),
+])
+```
+
+## Installation
+
+```bash
+uv add ace-framework[claude-sdk]
+```
+
+For observability, also install and configure Logfire:
+
+```bash
+uv add ace-framework[logfire]
+```
+
+```python
+from ace.observability import configure_logfire
+
+configure_logfire()
+```
+
+## What It Provides
+
+- `ClaudeSDKExecuteStep` — injects skillbook context, calls the Anthropic
+  Messages API, and writes a validated `ClaudeSDKResult` to `ctx.trace`
+- `ClaudeSDKToTrace` — converts `ClaudeSDKResult` into the standard ACE trace
+  dict consumed by `ReflectStep`
+- `ClaudeSDKResult` — Pydantic model with validated output, token usage,
+  latency, tool calls, and raw response access
+- `ToolCall` — Pydantic model for captured Claude tool invocations
+
+## Parameters
+
+### ClaudeSDKExecuteStep
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `model` | `str` | `"claude-sonnet-4-20250514"` | Claude model ID |
+| `system_prompt` | `str \| None` | `None` | Base system prompt |
+| `max_tokens` | `int` | `4096` | Maximum output tokens |
+| `temperature` | `float` | `0.0` | Sampling temperature |
+| `tools` | `list[dict] \| None` | `None` | Anthropic tool definitions |
+| `api_key` | `str \| None` | `None` | Optional API key override |
+| `base_url` | `str \| None` | `None` | Optional API base URL |
+| `inject_skillbook` | `bool` | `True` | Prepend skillbook context to the system prompt |
+| `client` | `Any` | `None` | Injected Anthropic client for testing or custom transport |
+
+## Observability
+
+When Logfire is configured, the step emits three layers of observability:
+
+1. Step-level `logfire.span(...)` around `ClaudeSDKExecuteStep`
+2. Structured `logfire.info(...)` and `logfire.error(...)` events with tokens,
+   latency, stop reason, and tool counts
+3. `logfire.instrument_anthropic(client)` auto-instrumentation for the
+   underlying SDK calls
+
+The result model also captures:
+
+- `input_tokens`
+- `output_tokens`
+- `total_tokens`
+- `latency_seconds`
+- `stop_reason`
+- `tool_calls`
+
+## Tool Use
+
+```python
+tools = [
+    {
+        "name": "get_weather",
+        "description": "Get the current weather for a city.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    }
+]
+
+execute = ClaudeSDKExecuteStep(
+    model="claude-sonnet-4-20250514",
+    tools=tools,
+)
+```
+
+If Claude returns tool use blocks, they are captured on
+`ClaudeSDKResult.tool_calls` as validated `ToolCall` models.
+
+## Validation
+
+`ClaudeSDKExecuteStep` validates its configuration with Pydantic before the
+client is constructed. `ClaudeSDKResult` and `ToolCall` are also Pydantic
+models, so invalid token counts, latency values, or malformed tool calls are
+rejected early.
+
+## What to Read Next
+
+- [Integration Pattern](../guides/integration.md) — the shared
+  INJECT/EXECUTE/LEARN design
+- [Composing Pipelines](../guides/composing-pipelines.md) — mix SDK steps with
+  other ACE steps

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,6 +1,8 @@
 # Integrations Overview
 
-ACE provides runners for popular agentic frameworks. Each runner adds self-improving learning to an existing agent with minimal code changes.
+ACE provides both runners and step-based integrations for popular agentic
+frameworks. Some integrations are full runners, while others are composable
+pipeline steps you can drop into a custom `Pipeline`.
 
 ## Available Integrations
 
@@ -10,6 +12,7 @@ ACE provides runners for popular agentic frameworks. Each runner adds self-impro
 | [`LangChain`](langchain.md) | LangChain Runnables | Chain inputs | Meso |
 | [`BrowserUse`](browser-use.md) | browser-use | Task strings | Meso |
 | [`ClaudeCode`](claude-code.md) | Claude Code CLI | Task strings | Meso |
+| [`Claude SDK`](claude-sdk.md) | Anthropic Python SDK | Task strings or `ACESample` | Meso |
 | [OpenClaw](openclaw.md) | OpenClaw transcripts | JSONL trace files | Meso |
 | [MCP Server](mcp.md) | MCP (stdio) | Tool calls | Micro |
 | [Opik](opik.md) | Opik observability | — | Monitoring |
@@ -42,6 +45,20 @@ chain = LangChain.from_model(my_runnable, ace_model="gpt-4o-mini")
 coder = ClaudeCode.from_model(working_dir="./project", ace_model="gpt-4o-mini")
 ```
 
+For direct Anthropic API usage without a runner, compose the SDK steps directly:
+
+```python
+from ace import Pipeline, Reflector, SkillManager, Skillbook, learning_tail
+from ace.integrations import ClaudeSDKExecuteStep, ClaudeSDKToTrace
+
+skillbook = Skillbook()
+pipe = Pipeline([
+    ClaudeSDKExecuteStep(model="claude-sonnet-4-20250514"),
+    ClaudeSDKToTrace(),
+    *learning_tail(Reflector("gpt-4o-mini"), SkillManager("gpt-4o-mini"), skillbook),
+])
+```
+
 ## Shared Features
 
 All runners share these capabilities:
@@ -58,6 +75,7 @@ All runners share these capabilities:
 - **Have an existing LangChain chain or agent?** Use [LangChain](langchain.md)
 - **Automating browser tasks?** Use [BrowserUse](browser-use.md)
 - **Running coding tasks with Claude Code?** Use [ClaudeCode](claude-code.md)
+- **Calling Anthropic directly from your own pipeline?** Use [Claude SDK](claude-sdk.md)
 - **Want to monitor costs and traces?** Add [Opik](opik.md)
 - **Learning from OpenClaw session transcripts?** Use [OpenClaw](openclaw.md)
 - **Exposing ACE as an MCP tool provider?** Use the [MCP Server](mcp.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
     - LangChain: integrations/langchain.md
     - Browser-Use: integrations/browser-use.md
     - Claude Code: integrations/claude-code.md
+    - Claude SDK: integrations/claude-sdk.md
     - Opik Observability: integrations/opik.md
     - OpenClaw: integrations/openclaw.md
     - Hosted API: integrations/hosted-api.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+claude-sdk = [
+    "anthropic>=0.76.0",
+]
 claude-code = [
     "python-dotenv>=1.0.0",
     "tenacity>=8.0.0",

--- a/tests/test_claude_sdk_live.py
+++ b/tests/test_claude_sdk_live.py
@@ -1,0 +1,475 @@
+"""Live integration tests for the Claude SDK step.
+
+These tests make REAL API calls to the Anthropic API. They require:
+- ``ANTHROPIC_API_KEY`` environment variable to be set
+- Network access to ``api.anthropic.com``
+
+Run with::
+
+    ANTHROPIC_API_KEY=sk-... uv run pytest tests/test_claude_sdk_live.py -v -m integration
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from ace.core.context import ACEStepContext, SkillbookView
+from ace.core.skillbook import Skillbook
+from ace.integrations.claude_sdk import (
+    ClaudeSDKExecuteStep,
+    ClaudeSDKResult,
+    ClaudeSDKToTrace,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.requires_api,
+    pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY"),
+        reason="ANTHROPIC_API_KEY not set",
+    ),
+]
+
+pytest.importorskip("anthropic")
+
+MODEL = "claude-sonnet-4-20250514"
+
+
+# ------------------------------------------------------------------ #
+# 1. Basic text generation
+# ------------------------------------------------------------------ #
+
+
+class TestBasicGeneration:
+    def test_simple_question(self):
+        """Verify a basic question returns a successful result with tokens."""
+        step = ClaudeSDKExecuteStep(model=MODEL, max_tokens=100)
+        ctx = ACEStepContext(
+            sample="What is 2+2? Answer with just the number.", skillbook=None
+        )
+
+        result_ctx = step(ctx)
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+
+        assert r.success is True
+        assert r.error is None
+        assert "4" in r.output
+        assert r.model == MODEL
+        assert r.stop_reason in ("end_turn", "max_tokens")
+        assert r.input_tokens > 0
+        assert r.output_tokens > 0
+        assert r.total_tokens == r.input_tokens + r.output_tokens
+        assert r.latency_seconds > 0
+        assert r.raw_response is not None
+
+    def test_longer_response(self):
+        """Verify the step handles multi-sentence responses."""
+        step = ClaudeSDKExecuteStep(model=MODEL, max_tokens=300)
+        ctx = ACEStepContext(
+            sample="Explain in 2-3 sentences why the sky is blue.",
+            skillbook=None,
+        )
+
+        result_ctx = step(ctx)
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+
+        assert r.success is True
+        assert len(r.output) > 50
+        assert r.output_tokens > 10
+
+
+# ------------------------------------------------------------------ #
+# 2. System prompt
+# ------------------------------------------------------------------ #
+
+
+class TestSystemPrompt:
+    def test_system_prompt_affects_output(self):
+        """A system prompt instructing a specific format should be followed."""
+        step = ClaudeSDKExecuteStep(
+            model=MODEL,
+            max_tokens=50,
+            system_prompt="You are a calculator. Only output numbers, nothing else.",
+        )
+        ctx = ACEStepContext(sample="What is 15 * 3?", skillbook=None)
+
+        result_ctx = step(ctx)
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+
+        assert r.success is True
+        assert "45" in r.output
+
+
+# ------------------------------------------------------------------ #
+# 3. Skillbook injection
+# ------------------------------------------------------------------ #
+
+
+class TestSkillbookInjection:
+    def test_skillbook_injected_into_system(self):
+        """When a skillbook has skills, they're injected and the model can reference them."""
+        sb = Skillbook()
+        sb.add_skill("math", "Always show step-by-step work for math problems")
+        sb.add_skill("format", "End every answer with 'QED'")
+
+        step = ClaudeSDKExecuteStep(
+            model=MODEL,
+            max_tokens=200,
+            inject_skillbook=True,
+        )
+        ctx = ACEStepContext(
+            sample="What is 7 * 8? Follow the strategies you've been given.",
+            skillbook=SkillbookView(sb),
+        )
+
+        result_ctx = step(ctx)
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+
+        assert r.success is True
+        assert "56" in r.output
+
+    def test_skillbook_injection_disabled(self):
+        """With inject_skillbook=False, skills are NOT sent to the model."""
+        sb = Skillbook()
+        sb.add_skill("format", "End every answer with the word BANANA")
+
+        step = ClaudeSDKExecuteStep(
+            model=MODEL,
+            max_tokens=50,
+            inject_skillbook=False,
+        )
+        ctx = ACEStepContext(
+            sample="What is 1+1? Just answer the number.",
+            skillbook=SkillbookView(sb),
+        )
+
+        result_ctx = step(ctx)
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+
+        assert r.success is True
+        assert "BANANA" not in r.output
+
+
+# ------------------------------------------------------------------ #
+# 4. Tool use
+# ------------------------------------------------------------------ #
+
+
+class TestToolUse:
+    def test_tool_call_returned(self):
+        """When given a tool, the model should call it and we capture the call."""
+        tools = [
+            {
+                "name": "get_weather",
+                "description": "Get the current weather for a city.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string", "description": "City name"},
+                    },
+                    "required": ["city"],
+                },
+            }
+        ]
+        step = ClaudeSDKExecuteStep(
+            model=MODEL,
+            max_tokens=200,
+            tools=tools,
+        )
+        ctx = ACEStepContext(
+            sample="What's the weather in Paris right now?",
+            skillbook=None,
+        )
+
+        result_ctx = step(ctx)
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+
+        assert r.success is True
+        assert r.stop_reason in ("tool_use", "end_turn")
+        if r.stop_reason == "tool_use":
+            assert len(r.tool_calls) >= 1
+            tc = r.tool_calls[0]
+            assert tc.name == "get_weather"
+            assert "city" in tc.input
+            assert tc.id.startswith("toolu_")
+
+
+# ------------------------------------------------------------------ #
+# 5. Temperature
+# ------------------------------------------------------------------ #
+
+
+class TestTemperature:
+    def test_zero_temperature_deterministic(self):
+        """Temperature 0 should produce near-identical outputs."""
+        step = ClaudeSDKExecuteStep(
+            model=MODEL,
+            max_tokens=20,
+            temperature=0.0,
+        )
+        ctx = ACEStepContext(
+            sample="Complete this: 1, 2, 3, 4, ",
+            skillbook=None,
+        )
+
+        r1: ClaudeSDKResult = step(ctx).trace  # type: ignore[assignment]
+        r2: ClaudeSDKResult = step(ctx).trace  # type: ignore[assignment]
+
+        assert r1.success and r2.success
+        # With temp=0 outputs should be identical or very similar
+        assert r1.output[:10] == r2.output[:10]
+
+
+# ------------------------------------------------------------------ #
+# 6. Error handling
+# ------------------------------------------------------------------ #
+
+
+class TestErrorHandling:
+    def test_invalid_model_returns_error(self):
+        """An invalid model name should return a failed result, not crash."""
+        step = ClaudeSDKExecuteStep(
+            model="claude-nonexistent-99",
+            max_tokens=10,
+        )
+        ctx = ACEStepContext(sample="hello", skillbook=None)
+
+        result_ctx = step(ctx)
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+
+        assert r.success is False
+        assert r.error is not None
+        assert r.latency_seconds >= 0
+
+    def test_max_tokens_respected(self):
+        """A very low max_tokens should truncate the response."""
+        step = ClaudeSDKExecuteStep(
+            model=MODEL,
+            max_tokens=5,
+        )
+        ctx = ACEStepContext(
+            sample="Write a 500-word essay about the history of computing.",
+            skillbook=None,
+        )
+
+        result_ctx = step(ctx)
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+
+        assert r.success is True
+        assert r.stop_reason == "max_tokens"
+        assert r.output_tokens <= 10  # small buffer around max_tokens
+
+
+# ------------------------------------------------------------------ #
+# 7. ToTrace conversion with real data
+# ------------------------------------------------------------------ #
+
+
+class TestToTraceWithRealData:
+    def test_full_pipeline_execute_then_convert(self):
+        """Run execute step then ToTrace step — end-to-end pipeline flow."""
+        execute = ClaudeSDKExecuteStep(model=MODEL, max_tokens=100)
+        to_trace = ClaudeSDKToTrace()
+
+        ctx = ACEStepContext(sample="What is the capital of France?", skillbook=None)
+
+        # Execute
+        ctx = execute(ctx)
+        r: ClaudeSDKResult = ctx.trace  # type: ignore[assignment]
+        assert r.success is True
+        assert "Paris" in r.output
+
+        # Convert
+        ctx = to_trace(ctx)
+        trace = ctx.trace
+        assert isinstance(trace, dict)
+        assert trace["question"] == "What is the capital of France?"
+        assert "Paris" in trace["answer"]
+        assert "succeeded" in trace["reasoning"]
+        assert str(r.input_tokens) in trace["reasoning"]
+        assert "succeeded" in trace["feedback"]
+        assert trace["ground_truth"] is None
+
+
+# ------------------------------------------------------------------ #
+# 8. ACESample input (structured sample)
+# ------------------------------------------------------------------ #
+
+
+class TestACESampleInput:
+    def test_structured_sample(self):
+        """Step should extract question+context from a structured sample."""
+        from dataclasses import dataclass
+
+        @dataclass
+        class Sample:
+            question: str = "What color is a ripe banana?"
+            context: str = "We are discussing fruits."
+            ground_truth: str = "yellow"
+            metadata: dict = None  # type: ignore[assignment]
+
+            def __post_init__(self):
+                self.metadata = self.metadata or {}
+
+        step = ClaudeSDKExecuteStep(model=MODEL, max_tokens=30)
+        ctx = ACEStepContext(sample=Sample(), skillbook=None)
+
+        result_ctx = step(ctx)
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+
+        assert r.success is True
+        assert r.task  # task was extracted
+        assert "banana" in r.task.lower() or "color" in r.task.lower()
+
+
+# ------------------------------------------------------------------ #
+# 9. Observability data quality
+# ------------------------------------------------------------------ #
+
+
+class TestObservabilityData:
+    def test_token_counts_realistic(self):
+        """Token counts should be reasonable for a simple prompt."""
+        step = ClaudeSDKExecuteStep(model=MODEL, max_tokens=50)
+        ctx = ACEStepContext(sample="Say 'hello world'", skillbook=None)
+
+        result_ctx = step(ctx)
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+
+        assert r.success is True
+        # Input: system overhead + short prompt, should be < 100
+        assert 1 < r.input_tokens < 100
+        # Output: short response
+        assert 1 < r.output_tokens <= 50
+        # Total is sum
+        assert r.total_tokens == r.input_tokens + r.output_tokens
+        # Latency > 0 and reasonable (< 30s for a short request)
+        assert 0 < r.latency_seconds < 30
+
+    def test_model_field_matches_request(self):
+        """The model field in the result should match what we requested."""
+        step = ClaudeSDKExecuteStep(model=MODEL, max_tokens=10)
+        ctx = ACEStepContext(sample="hi", skillbook=None)
+
+        result_ctx = step(ctx)
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+
+        assert r.model == MODEL
+
+
+# ------------------------------------------------------------------ #
+# 10. Pydantic validation on real results
+# ------------------------------------------------------------------ #
+
+
+class TestPydanticValidation:
+    def test_result_is_pydantic_model(self):
+        """ClaudeSDKResult should be a Pydantic BaseModel."""
+        from pydantic import BaseModel
+
+        step = ClaudeSDKExecuteStep(model=MODEL, max_tokens=10)
+        ctx = ACEStepContext(sample="hi", skillbook=None)
+
+        result_ctx = step(ctx)
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+
+        assert isinstance(r, BaseModel)
+
+    def test_model_dump(self):
+        """Real result should serialise cleanly, with raw_response excluded."""
+        step = ClaudeSDKExecuteStep(model=MODEL, max_tokens=20)
+        ctx = ACEStepContext(sample="Say hello", skillbook=None)
+
+        result_ctx = step(ctx)
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+
+        d = r.model_dump()
+        assert isinstance(d, dict)
+        assert d["success"] is True
+        assert d["input_tokens"] > 0
+        assert d["output_tokens"] > 0
+        assert d["total_tokens"] == d["input_tokens"] + d["output_tokens"]
+        assert "raw_response" not in d
+
+    def test_model_dump_json(self):
+        """Result should serialise to JSON string."""
+        import json
+
+        step = ClaudeSDKExecuteStep(model=MODEL, max_tokens=10)
+        ctx = ACEStepContext(sample="hi", skillbook=None)
+
+        result_ctx = step(ctx)
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+
+        j = r.model_dump_json()
+        parsed = json.loads(j)
+        assert parsed["task"] == "hi"
+        assert parsed["success"] is True
+
+    def test_total_tokens_auto_computed(self):
+        """total_tokens should equal input + output on a real response."""
+        step = ClaudeSDKExecuteStep(model=MODEL, max_tokens=20)
+        ctx = ACEStepContext(sample="Count to 3", skillbook=None)
+
+        result_ctx = step(ctx)
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+
+        assert r.total_tokens == r.input_tokens + r.output_tokens
+        assert r.total_tokens > 0
+
+    def test_tool_calls_are_pydantic_models(self):
+        """Tool calls in the result should be validated ToolCall models."""
+        from ace.integrations.claude_sdk import ToolCall
+
+        tools = [
+            {
+                "name": "lookup",
+                "description": "Look up a value.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"key": {"type": "string"}},
+                    "required": ["key"],
+                },
+            }
+        ]
+        step = ClaudeSDKExecuteStep(model=MODEL, max_tokens=100, tools=tools)
+        ctx = ACEStepContext(sample="Look up the value of 'pi'", skillbook=None)
+
+        result_ctx = step(ctx)
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+
+        assert r.success is True
+        if r.tool_calls:
+            tc = r.tool_calls[0]
+            assert isinstance(tc, ToolCall)
+            assert isinstance(tc.id, str)
+            assert isinstance(tc.name, str)
+            assert isinstance(tc.input, dict)
+
+
+# ------------------------------------------------------------------ #
+# 11. Logfire integration (real)
+# ------------------------------------------------------------------ #
+
+
+class TestLogfireIntegration:
+    def test_logfire_configure_and_instrument(self):
+        """Configure Logfire, create a step, make a call — verify spans are sent."""
+        from ace.observability import configure_logfire, is_configured
+
+        configured = configure_logfire()
+        if not configured:
+            pytest.skip("Logfire not configured (missing LOGFIRE_TOKEN?)")
+
+        assert is_configured()
+
+        step = ClaudeSDKExecuteStep(model=MODEL, max_tokens=20)
+        ctx = ACEStepContext(sample="Say 'logfire test'", skillbook=None)
+
+        result_ctx = step(ctx)
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+
+        assert r.success is True
+        assert r.output_tokens > 0

--- a/tests/test_claude_sdk_step.py
+++ b/tests/test_claude_sdk_step.py
@@ -1,0 +1,616 @@
+"""Tests for the Claude SDK integration step."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from ace.core.context import ACEStepContext, SkillbookView
+from ace.core.skillbook import Skillbook
+from ace.integrations.claude_sdk import (
+    ClaudeSDKExecuteStep,
+    ClaudeSDKResult,
+    ClaudeSDKToTrace,
+    ToolCall,
+)
+
+# ------------------------------------------------------------------ #
+# Helpers — mock Anthropic API objects
+# ------------------------------------------------------------------ #
+
+
+def _make_text_block(text: str) -> SimpleNamespace:
+    return SimpleNamespace(type="text", text=text)
+
+
+def _make_tool_block(
+    tool_id: str = "toolu_01", name: str = "calculator", inp: Any = None
+) -> SimpleNamespace:
+    return SimpleNamespace(type="tool_use", id=tool_id, name=name, input=inp or {})
+
+
+def _make_usage(input_tokens: int = 100, output_tokens: int = 50) -> SimpleNamespace:
+    return SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens)
+
+
+def _make_response(
+    content: list | None = None,
+    model: str = "claude-sonnet-4-20250514",
+    stop_reason: str = "end_turn",
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+) -> SimpleNamespace:
+    if content is None:
+        content = [_make_text_block("Hello, world!")]
+    return SimpleNamespace(
+        content=content,
+        model=model,
+        stop_reason=stop_reason,
+        usage=_make_usage(input_tokens, output_tokens),
+    )
+
+
+def _make_mock_client(response: SimpleNamespace | None = None) -> MagicMock:
+    client = MagicMock()
+    client.messages.create.return_value = response or _make_response()
+    return client
+
+
+@dataclass
+class FakeSample:
+    question: str = "What is 2+2?"
+    context: str = "math quiz"
+    ground_truth: str = "4"
+    metadata: dict = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.metadata is None:
+            self.metadata = {}
+
+
+# ------------------------------------------------------------------ #
+# ClaudeSDKResult
+# ------------------------------------------------------------------ #
+
+
+class TestClaudeSDKResult:
+    def test_defaults(self):
+        r = ClaudeSDKResult(task="test", success=True)
+        assert r.task == "test"
+        assert r.success is True
+        assert r.output == ""
+        assert r.error is None
+        assert r.input_tokens == 0
+        assert r.output_tokens == 0
+        assert r.total_tokens == 0
+        assert r.latency_seconds == 0.0
+        assert r.tool_calls == []
+        assert r.cited_skill_ids == []
+        assert r.raw_response is None
+
+    def test_full(self):
+        tc = ToolCall(id="toolu_01", name="calc", input={"expr": "1+1"})
+        r = ClaudeSDKResult(
+            task="hello",
+            success=True,
+            output="world",
+            model="claude-sonnet-4-20250514",
+            stop_reason="end_turn",
+            input_tokens=100,
+            output_tokens=50,
+            total_tokens=150,
+            latency_seconds=1.5,
+            tool_calls=[tc],
+            cited_skill_ids=["math-001"],
+        )
+        assert r.total_tokens == 150
+        assert r.tool_calls[0].name == "calc"
+
+    def test_auto_compute_total_tokens(self):
+        """total_tokens is auto-computed from input + output when left at 0."""
+        r = ClaudeSDKResult(
+            task="test", success=True, input_tokens=100, output_tokens=50
+        )
+        assert r.total_tokens == 150
+
+    def test_explicit_total_not_overwritten(self):
+        """An explicitly set total_tokens is preserved."""
+        r = ClaudeSDKResult(
+            task="test",
+            success=True,
+            input_tokens=100,
+            output_tokens=50,
+            total_tokens=999,
+        )
+        assert r.total_tokens == 999
+
+    def test_negative_tokens_rejected(self):
+        """Negative token counts should be rejected by validation."""
+        with pytest.raises(Exception):
+            ClaudeSDKResult(task="test", success=True, input_tokens=-1)
+
+    def test_negative_latency_rejected(self):
+        """Negative latency should be rejected by validation."""
+        with pytest.raises(Exception):
+            ClaudeSDKResult(task="test", success=True, latency_seconds=-0.1)
+
+    def test_serialization(self):
+        """Result should serialise to dict/JSON (raw_response excluded)."""
+        r = ClaudeSDKResult(
+            task="test",
+            success=True,
+            input_tokens=10,
+            output_tokens=5,
+            raw_response=object(),
+        )
+        d = r.model_dump()
+        assert d["task"] == "test"
+        assert "raw_response" not in d  # excluded
+
+    def test_tool_call_validation(self):
+        """ToolCall should validate required fields."""
+        tc = ToolCall(id="toolu_01", name="calc")
+        assert tc.input == {}
+
+        with pytest.raises(Exception):
+            ToolCall(name="calc")  # missing id
+
+
+# ------------------------------------------------------------------ #
+# ClaudeSDKExecuteStep — contracts
+# ------------------------------------------------------------------ #
+
+
+class TestClaudeSDKExecuteStepContracts:
+    def test_requires_and_provides(self):
+        client = _make_mock_client()
+        step = ClaudeSDKExecuteStep(client=client)
+        assert "sample" in step.requires
+        assert "skillbook" in step.requires
+        assert "trace" in step.provides
+
+    def test_not_available_raises_without_client(self):
+        with patch("ace.integrations.claude_sdk.ANTHROPIC_SDK_AVAILABLE", False):
+            with pytest.raises(ImportError, match="anthropic SDK not installed"):
+                ClaudeSDKExecuteStep()
+
+    def test_injected_client_skips_availability_check(self):
+        with patch("ace.integrations.claude_sdk.ANTHROPIC_SDK_AVAILABLE", False):
+            step = ClaudeSDKExecuteStep(client=_make_mock_client())
+            assert "sample" in step.requires
+
+    def test_invalid_max_tokens_rejected(self):
+        with pytest.raises(ValidationError):
+            ClaudeSDKExecuteStep(client=_make_mock_client(), max_tokens=0)
+
+    def test_invalid_temperature_rejected(self):
+        with pytest.raises(ValidationError):
+            ClaudeSDKExecuteStep(client=_make_mock_client(), temperature=1.5)
+
+
+# ------------------------------------------------------------------ #
+# ClaudeSDKExecuteStep — execution
+# ------------------------------------------------------------------ #
+
+
+class TestClaudeSDKExecuteStepExecution:
+    def test_basic_call(self):
+        response = _make_response(
+            content=[_make_text_block("The answer is 4")],
+            input_tokens=80,
+            output_tokens=20,
+        )
+        client = _make_mock_client(response)
+        step = ClaudeSDKExecuteStep(client=client, model="claude-sonnet-4-20250514")
+
+        ctx = ACEStepContext(sample="What is 2+2?", skillbook=None)
+        result_ctx = step(ctx)
+
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+        assert r.success is True
+        assert r.output == "The answer is 4"
+        assert r.input_tokens == 80
+        assert r.output_tokens == 20
+        assert r.total_tokens == 100
+        assert r.latency_seconds >= 0
+        assert r.model == "claude-sonnet-4-20250514"
+        assert r.stop_reason == "end_turn"
+
+        # Verify API was called correctly
+        call_kwargs = client.messages.create.call_args[1]
+        assert call_kwargs["model"] == "claude-sonnet-4-20250514"
+        assert call_kwargs["messages"] == [{"role": "user", "content": "What is 2+2?"}]
+
+    def test_with_system_prompt(self):
+        client = _make_mock_client()
+        step = ClaudeSDKExecuteStep(
+            client=client,
+            system_prompt="You are a math tutor.",
+        )
+
+        ctx = ACEStepContext(sample="What is 2+2?", skillbook=None)
+        step(ctx)
+
+        call_kwargs = client.messages.create.call_args[1]
+        assert call_kwargs["system"] == "You are a math tutor."
+
+    def test_skillbook_injection(self):
+        client = _make_mock_client()
+        step = ClaudeSDKExecuteStep(client=client, inject_skillbook=True)
+
+        sb = Skillbook()
+        sb.add_skill("math", "Always show your work")
+        ctx = ACEStepContext(sample="What is 2+2?", skillbook=SkillbookView(sb))
+        step(ctx)
+
+        call_kwargs = client.messages.create.call_args[1]
+        assert "system" in call_kwargs
+        assert "Strategic Knowledge" in call_kwargs["system"]
+
+    def test_skillbook_injection_with_system_prompt(self):
+        client = _make_mock_client()
+        step = ClaudeSDKExecuteStep(
+            client=client,
+            system_prompt="You are a tutor.",
+            inject_skillbook=True,
+        )
+
+        sb = Skillbook()
+        sb.add_skill("math", "Show work")
+        ctx = ACEStepContext(sample="test", skillbook=SkillbookView(sb))
+        step(ctx)
+
+        call_kwargs = client.messages.create.call_args[1]
+        system = call_kwargs["system"]
+        assert "You are a tutor." in system
+        assert "Strategic Knowledge" in system
+
+    def test_skillbook_injection_disabled(self):
+        client = _make_mock_client()
+        step = ClaudeSDKExecuteStep(client=client, inject_skillbook=False)
+
+        sb = Skillbook()
+        sb.add_skill("math", "Show work")
+        ctx = ACEStepContext(sample="test", skillbook=SkillbookView(sb))
+        step(ctx)
+
+        call_kwargs = client.messages.create.call_args[1]
+        assert "system" not in call_kwargs
+
+    def test_empty_skillbook_no_system(self):
+        client = _make_mock_client()
+        step = ClaudeSDKExecuteStep(client=client, inject_skillbook=True)
+
+        sb = Skillbook()
+        ctx = ACEStepContext(sample="test", skillbook=SkillbookView(sb))
+        step(ctx)
+
+        call_kwargs = client.messages.create.call_args[1]
+        assert "system" not in call_kwargs
+
+    def test_with_tools(self):
+        tools = [
+            {
+                "name": "calculator",
+                "description": "A calculator",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"expr": {"type": "string"}},
+                },
+            }
+        ]
+        response = _make_response(
+            content=[
+                _make_tool_block("toolu_01", "calculator", {"expr": "2+2"}),
+                _make_text_block("The result is 4"),
+            ]
+        )
+        client = _make_mock_client(response)
+        step = ClaudeSDKExecuteStep(client=client, tools=tools)
+
+        ctx = ACEStepContext(sample="Calculate 2+2", skillbook=None)
+        result_ctx = step(ctx)
+
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+        assert r.success is True
+        assert r.output == "The result is 4"
+        assert len(r.tool_calls) == 1
+        assert r.tool_calls[0].name == "calculator"
+        assert r.tool_calls[0].input == {"expr": "2+2"}
+
+        call_kwargs = client.messages.create.call_args[1]
+        assert call_kwargs["tools"] == tools
+
+    def test_api_error_handled(self):
+        client = _make_mock_client()
+        client.messages.create.side_effect = RuntimeError("API down")
+        step = ClaudeSDKExecuteStep(client=client)
+
+        ctx = ACEStepContext(sample="test", skillbook=None)
+        result_ctx = step(ctx)
+
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+        assert r.success is False
+        assert "API down" in r.error
+        assert r.latency_seconds >= 0
+
+    def test_temperature_and_max_tokens(self):
+        client = _make_mock_client()
+        step = ClaudeSDKExecuteStep(client=client, temperature=0.7, max_tokens=1024)
+
+        ctx = ACEStepContext(sample="test", skillbook=None)
+        step(ctx)
+
+        call_kwargs = client.messages.create.call_args[1]
+        assert call_kwargs["temperature"] == 0.7
+        assert call_kwargs["max_tokens"] == 1024
+
+
+# ------------------------------------------------------------------ #
+# ClaudeSDKExecuteStep — task extraction
+# ------------------------------------------------------------------ #
+
+
+class TestClaudeSDKTaskExtraction:
+    def test_string_sample(self):
+        assert ClaudeSDKExecuteStep._extract_task("hello") == "hello"
+
+    def test_sample_with_question(self):
+        sample = FakeSample(question="What is 2+2?", context="")
+        result = ClaudeSDKExecuteStep._extract_task(sample)
+        assert result == "What is 2+2?"
+
+    def test_sample_with_context(self):
+        sample = FakeSample(question="What is 2+2?", context="math quiz")
+        result = ClaudeSDKExecuteStep._extract_task(sample)
+        assert "What is 2+2?" in result
+        assert "Context: math quiz" in result
+
+    def test_arbitrary_object(self):
+        result = ClaudeSDKExecuteStep._extract_task(42)
+        assert result == "42"
+
+
+# ------------------------------------------------------------------ #
+# ClaudeSDKExecuteStep — skill ID extraction
+# ------------------------------------------------------------------ #
+
+
+class TestClaudeSDKSkillExtraction:
+    def test_extracts_skill_ids(self):
+        response = _make_response(
+            content=[
+                _make_text_block(
+                    "Following [math-00001], the answer is 4. "
+                    "Also [general-00042] applies."
+                )
+            ]
+        )
+        client = _make_mock_client(response)
+        step = ClaudeSDKExecuteStep(client=client)
+
+        ctx = ACEStepContext(sample="test", skillbook=None)
+        result_ctx = step(ctx)
+
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+        assert "math-00001" in r.cited_skill_ids
+        assert "general-00042" in r.cited_skill_ids
+
+    def test_no_skill_ids(self):
+        response = _make_response(content=[_make_text_block("No citations here")])
+        client = _make_mock_client(response)
+        step = ClaudeSDKExecuteStep(client=client)
+
+        ctx = ACEStepContext(sample="test", skillbook=None)
+        result_ctx = step(ctx)
+
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+        assert r.cited_skill_ids == []
+
+
+# ------------------------------------------------------------------ #
+# ClaudeSDKExecuteStep — observability logging
+# ------------------------------------------------------------------ #
+
+
+class TestClaudeSDKObservability:
+    def test_auto_instruments_anthropic_when_logfire_configured(self):
+        mock_logfire = MagicMock()
+        mock_ctx = MagicMock()
+        mock_logfire.instrument_anthropic.return_value = mock_ctx
+
+        with (
+            patch("ace.observability.is_configured", return_value=True),
+            patch.dict("sys.modules", {"logfire": mock_logfire}),
+        ):
+            step = ClaudeSDKExecuteStep(client=_make_mock_client())
+
+        mock_logfire.instrument_anthropic.assert_called_once_with(step._client)
+        mock_ctx.__enter__.assert_not_called()
+
+    def test_logs_metrics(self, caplog):
+        response = _make_response(input_tokens=200, output_tokens=100)
+        client = _make_mock_client(response)
+        step = ClaudeSDKExecuteStep(client=client)
+
+        with caplog.at_level(logging.INFO, logger="ace.integrations.claude_sdk"):
+            ctx = ACEStepContext(sample="test", skillbook=None)
+            step(ctx)
+
+        assert "ClaudeSDK:" in caplog.text
+        assert "tokens=" in caplog.text
+
+    def test_logs_error(self, caplog):
+        client = _make_mock_client()
+        client.messages.create.side_effect = RuntimeError("boom")
+        step = ClaudeSDKExecuteStep(client=client)
+
+        with caplog.at_level(logging.ERROR, logger="ace.integrations.claude_sdk"):
+            ctx = ACEStepContext(sample="test", skillbook=None)
+            step(ctx)
+
+        assert "failed" in caplog.text.lower()
+
+    def test_logfire_span_on_success(self):
+        """When Logfire is configured, __call__ opens a span with attributes."""
+        mock_span = MagicMock()
+        mock_logfire = MagicMock()
+        mock_logfire.span.return_value.__enter__ = MagicMock(return_value=mock_span)
+        mock_logfire.span.return_value.__exit__ = MagicMock(return_value=False)
+
+        response = _make_response(input_tokens=50, output_tokens=25)
+        client = _make_mock_client(response)
+        step = ClaudeSDKExecuteStep(client=client)
+
+        with (
+            patch(
+                "ace.integrations.claude_sdk._get_logfire", return_value=mock_logfire
+            ),
+        ):
+            ctx = ACEStepContext(sample="What is 2+2?", skillbook=None)
+            result_ctx = step(ctx)
+
+        # Span was opened
+        mock_logfire.span.assert_called_once()
+        call_kwargs = mock_logfire.span.call_args
+        assert call_kwargs[0][0] == "ClaudeSDKExecuteStep"
+        assert call_kwargs[1]["model"] == "claude-sonnet-4-20250514"
+
+        # Attributes were set on the span
+        attr_calls = {c[0][0]: c[0][1] for c in mock_span.set_attribute.call_args_list}
+        assert attr_calls["success"] is True
+        assert attr_calls["input_tokens"] == 50
+        assert attr_calls["output_tokens"] == 25
+        assert attr_calls["total_tokens"] == 75
+        assert "error" not in attr_calls
+
+        # logfire.info was called with metrics
+        mock_logfire.info.assert_called_once()
+        info_kwargs = mock_logfire.info.call_args[1]
+        assert info_kwargs["input_tokens"] == 50
+        assert info_kwargs["output_tokens"] == 25
+
+    def test_logfire_span_on_failure(self):
+        """On API error, span captures error attribute and logfire.error is called."""
+        mock_span = MagicMock()
+        mock_logfire = MagicMock()
+        mock_logfire.span.return_value.__enter__ = MagicMock(return_value=mock_span)
+        mock_logfire.span.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = _make_mock_client()
+        client.messages.create.side_effect = RuntimeError("rate limited")
+        step = ClaudeSDKExecuteStep(client=client)
+
+        with (
+            patch(
+                "ace.integrations.claude_sdk._get_logfire", return_value=mock_logfire
+            ),
+        ):
+            ctx = ACEStepContext(sample="test", skillbook=None)
+            step(ctx)
+
+        # Span captured the error attribute
+        attr_calls = {c[0][0]: c[0][1] for c in mock_span.set_attribute.call_args_list}
+        assert attr_calls["success"] is False
+        assert "rate limited" in attr_calls["error"]
+
+        # logfire.error was called
+        mock_logfire.error.assert_called_once()
+        error_kwargs = mock_logfire.error.call_args[1]
+        assert "rate limited" in error_kwargs["error"]
+
+    def test_no_logfire_noop(self):
+        """When Logfire is not configured, execution proceeds without spans."""
+        client = _make_mock_client()
+        step = ClaudeSDKExecuteStep(client=client)
+
+        with patch("ace.integrations.claude_sdk._get_logfire", return_value=None):
+            ctx = ACEStepContext(sample="test", skillbook=None)
+            result_ctx = step(ctx)
+
+        r: ClaudeSDKResult = result_ctx.trace  # type: ignore[assignment]
+        assert r.success is True
+
+
+# ------------------------------------------------------------------ #
+# ClaudeSDKToTrace
+# ------------------------------------------------------------------ #
+
+
+class TestClaudeSDKToTrace:
+    def test_requires_and_provides(self):
+        step = ClaudeSDKToTrace()
+        assert "trace" in step.requires
+        assert "trace" in step.provides
+
+    def test_success_trace(self):
+        r = ClaudeSDKResult(
+            task="What is 2+2?",
+            success=True,
+            output="4",
+            model="claude-sonnet-4-20250514",
+            stop_reason="end_turn",
+            input_tokens=100,
+            output_tokens=50,
+            total_tokens=150,
+            latency_seconds=1.2,
+            cited_skill_ids=["math-001"],
+        )
+        ctx = ACEStepContext(trace=r)
+        result_ctx = ClaudeSDKToTrace()(ctx)
+
+        trace = result_ctx.trace
+        assert trace["question"] == "What is 2+2?"
+        assert trace["answer"] == "4"
+        assert trace["skill_ids"] == ["math-001"]
+        assert "succeeded" in trace["reasoning"]
+        assert "claude-sonnet-4-20250514" in trace["reasoning"]
+        assert "100" in trace["reasoning"]  # input tokens
+        assert "50" in trace["reasoning"]  # output tokens
+        assert "1.2" in trace["reasoning"]  # latency
+        assert "succeeded" in trace["feedback"]
+        assert trace["ground_truth"] is None
+
+    def test_failure_trace(self):
+        r = ClaudeSDKResult(
+            task="fail",
+            success=False,
+            error="API timeout",
+            model="claude-sonnet-4-20250514",
+            latency_seconds=30.0,
+        )
+        ctx = ACEStepContext(trace=r)
+        result_ctx = ClaudeSDKToTrace()(ctx)
+
+        trace = result_ctx.trace
+        assert trace["question"] == "fail"
+        assert trace["answer"] == ""
+        assert "failed" in trace["reasoning"]
+        assert "API timeout" in trace["reasoning"]
+        assert "failed" in trace["feedback"]
+        assert "API timeout" in trace["feedback"]
+
+    def test_tool_calls_in_reasoning(self):
+        r = ClaudeSDKResult(
+            task="calc",
+            success=True,
+            output="4",
+            model="claude-sonnet-4-20250514",
+            tool_calls=[
+                ToolCall(id="toolu_01", name="calculator", input={"expr": "2+2"}),
+                ToolCall(id="toolu_02", name="formatter"),
+            ],
+        )
+        ctx = ACEStepContext(trace=r)
+        result_ctx = ClaudeSDKToTrace()(ctx)
+
+        trace = result_ctx.trace
+        assert "Tool calls (2)" in trace["reasoning"]
+        assert "calculator" in trace["reasoning"]
+        assert "formatter" in trace["reasoning"]

--- a/uv.lock
+++ b/uv.lock
@@ -33,7 +33,7 @@ wheels = [
 
 [[package]]
 name = "ace-framework"
-version = "0.8.9"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },
@@ -73,6 +73,10 @@ bedrock = [
 browser-use = [
     { name = "browser-use", version = "0.11.13", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform == 'win32'" },
     { name = "browser-use", version = "0.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+]
+claude-sdk = [
+    { name = "anthropic", version = "0.76.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "anthropic", version = "0.84.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform == 'win32'" },
 ]
 claude-code = [
     { name = "python-dotenv", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
@@ -148,6 +152,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.42.50" },
     { name = "browser-use", marker = "extra == 'all'", specifier = ">=0.9.0" },
     { name = "browser-use", marker = "extra == 'browser-use'", specifier = ">=0.9.0" },
+    { name = "anthropic", marker = "extra == 'claude-sdk'", specifier = ">=0.76.0" },
     { name = "click", marker = "extra == 'all'", specifier = ">=8.1.0" },
     { name = "click", marker = "extra == 'cloud'", specifier = ">=8.1.0" },
     { name = "instructor", marker = "extra == 'all'", specifier = ">=1.0.0" },
@@ -186,7 +191,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'all'", specifier = ">=4.30.0" },
     { name = "transformers", marker = "extra == 'transformers'", specifier = ">=4.30.0" },
 ]
-provides-extras = ["claude-code", "instructor", "deduplication", "browser-use", "logfire", "bedrock", "langchain", "transformers", "all", "cloud", "mcp"]
+provides-extras = ["claude-sdk", "claude-code", "instructor", "deduplication", "browser-use", "logfire", "bedrock", "langchain", "transformers", "all", "cloud", "mcp"]
 
 [package.metadata.requires-dev]
 demos = [


### PR DESCRIPTION
## Summary
- add a pipeline-native Claude SDK integration with `ClaudeSDKExecuteStep`, `ClaudeSDKToTrace`, and validated result models
- document installation, usage, and the integration pattern across the docs and site nav
- add unit and live integration tests for the Claude SDK integration

## Testing
- uv run pytest tests/test_claude_sdk_step.py --no-cov -q

## Notes
- the PR branch was cut cleanly from `origin/main` and cherry-picked to include only the Claude SDK change set
