### PR TITLE
docs(mcp): add client setup guide and compatibility tests

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -15,6 +15,7 @@ pipeline steps you can drop into a custom `Pipeline`.
 | [`Claude SDK`](claude-sdk.md) | Anthropic Python SDK | Task strings or `ACESample` | Meso |
 | [OpenClaw](openclaw.md) | OpenClaw transcripts | JSONL trace files | Meso |
 | [MCP Server](mcp.md) | MCP (stdio) | Tool calls | Micro |
+| [MCP Client Setup](mcp-client-setup.md) | Claude Code, Cursor, Windsurf | — | Setup Guide |
 | [Opik](opik.md) | Opik observability | — | Monitoring |
 | [Hosted API](hosted-api.md) | Kayba hosted API | Trace files | Cloud |
 
@@ -78,6 +79,6 @@ All runners share these capabilities:
 - **Calling Anthropic directly from your own pipeline?** Use [Claude SDK](claude-sdk.md)
 - **Want to monitor costs and traces?** Add [Opik](opik.md)
 - **Learning from OpenClaw session transcripts?** Use [OpenClaw](openclaw.md)
-- **Exposing ACE as an MCP tool provider?** Use the [MCP Server](mcp.md)
+- **Exposing ACE as an MCP tool provider?** Use the [MCP Server](mcp.md) and the [MCP Client Setup](mcp-client-setup.md) guide
 - **Want to use the hosted API instead of running locally?** Use the [Hosted API](hosted-api.md) CLI
 - **Using a different framework?** See the [Integration Guide](../guides/integration.md) to build a custom runner

--- a/docs/integrations/mcp-client-setup.md
+++ b/docs/integrations/mcp-client-setup.md
@@ -1,0 +1,142 @@
+# ACE MCP Client Setup
+
+The ACE MCP server runs over `stdio`, so any MCP client that can launch a
+local command can connect to it.
+
+This guide focuses on wiring `ace-mcp` into popular clients. For the full
+tool reference, environment variables, and safety controls, see the
+[MCP Server guide](mcp.md).
+
+## Prerequisites
+
+1. Install ACE with the MCP extra:
+
+   ```bash
+   pip install "ace-framework[mcp]"
+   # or
+   uv add "ace-framework[mcp]"
+   ```
+
+2. Set the model and provider credentials you want the server to use:
+
+   ```bash
+   export ACE_MCP_DEFAULT_MODEL="gpt-4o-mini"
+   export OPENAI_API_KEY="sk-..."
+   ```
+
+3. Verify the server starts:
+
+   ```bash
+   ace-mcp
+   ```
+
+   It should log startup information to stderr and then wait for stdio input.
+
+## Claude Code
+
+Anthropic recommends managing Claude Code MCP servers with the `claude mcp`
+commands. A user-scoped server can be added with:
+
+```bash
+claude mcp add-json -s user ace '{
+  "type": "stdio",
+  "command": "ace-mcp",
+  "env": {
+    "ACE_MCP_DEFAULT_MODEL": "gpt-4o-mini",
+    "OPENAI_API_KEY": "sk-..."
+  }
+}'
+```
+
+Useful variants:
+
+- `-s project` stores the server in `.mcp.json` for the current repo.
+- `claude mcp list` shows configured servers.
+- `claude mcp get ace` prints the saved config.
+
+Once added, you can ask Claude Code to use ACE directly:
+
+```text
+Use ace.ask with session_id "repo-default" to summarize the conventions in this repo.
+```
+
+## Cursor
+
+Cursor supports local stdio MCP servers. Add a server from the MCP settings UI
+or your MCP config using this shape:
+
+```json
+{
+  "mcpServers": {
+    "ace": {
+      "command": "ace-mcp",
+      "env": {
+        "ACE_MCP_DEFAULT_MODEL": "gpt-4o-mini",
+        "OPENAI_API_KEY": "sk-..."
+      }
+    }
+  }
+}
+```
+
+After saving, refresh MCP servers in Cursor and confirm the ACE tools appear.
+
+## Windsurf
+
+Windsurf exposes MCP configuration through **Windsurf Settings** >
+**Cascade** > **MCP Servers**. Add a stdio server using the same command/env
+shape:
+
+```json
+{
+  "mcpServers": {
+    "ace": {
+      "command": "ace-mcp",
+      "env": {
+        "ACE_MCP_DEFAULT_MODEL": "gpt-4o-mini",
+        "OPENAI_API_KEY": "sk-..."
+      }
+    }
+  }
+}
+```
+
+Restart the MCP connection if the tools do not appear immediately.
+
+## Smoke Test with MCP Inspector
+
+Before debugging a client-specific setup, verify the server generically with
+the MCP Inspector:
+
+```bash
+npx @modelcontextprotocol/inspector ace-mcp
+```
+
+If the server starts and the six ACE tools appear, the remaining work is
+client configuration rather than ACE itself.
+
+## Troubleshooting
+
+### `ace-mcp` is not found
+
+- Confirm the package was installed with the `mcp` extra.
+- Run `which ace-mcp` (or the equivalent on your platform) and use the full
+  path in the client config if needed.
+
+### The client connects but no tools appear
+
+- Start `ace-mcp` manually first to confirm it launches cleanly.
+- Check stderr logs from the server.
+- Set `ACE_MCP_LOG_LEVEL=DEBUG` for more verbose logging.
+
+### Save/load should stay inside a safe directory
+
+Set `ACE_MCP_SKILLBOOK_ROOT` to constrain `ace.skillbook.save` and
+`ace.skillbook.load` to a specific directory.
+
+## References
+
+- [Anthropic: Claude Code MCP](https://docs.anthropic.com/en/docs/claude-code/mcp)
+- [Anthropic: Claude Code settings and scopes](https://code.claude.com/docs/en/settings)
+- [Cursor MCP docs](https://docs.cursor.com/advanced/model-context-protocol)
+- [Windsurf MCP docs](https://docs.windsurf.com/en/windsurf/cascade/mcp)

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -4,6 +4,8 @@ ACE (Agentic Context Engine) provides an optional MCP server that exposes ACE as
 
 The integration is fully opt-in. Installing ACE without the `mcp` extra does not pull in the MCP SDK, and attempting to start `ace-mcp` without that extra will fail with an install hint instead of breaking normal ACE imports.
 
+> Need client-specific setup steps? See the [MCP Client Setup](mcp-client-setup.md) guide.
+
 ## Installation
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,8 @@ nav:
     - Browser-Use: integrations/browser-use.md
     - Claude Code: integrations/claude-code.md
     - Claude SDK: integrations/claude-sdk.md
+    - MCP Server: integrations/mcp.md
+    - MCP Client Setup: integrations/mcp-client-setup.md
     - Opik Observability: integrations/opik.md
     - OpenClaw: integrations/openclaw.md
     - Hosted API: integrations/hosted-api.md

--- a/tests/test_ace_mcp_compatibility.py
+++ b/tests/test_ace_mcp_compatibility.py
@@ -1,0 +1,172 @@
+"""Focused compatibility tests for ACE's generic MCP server surface."""
+
+from __future__ import annotations
+
+import json
+import re
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ace.integrations.mcp.adapters import _MCP_INSTALL_HINT as ADAPTERS_INSTALL_HINT
+from ace.integrations.mcp.adapters import _mcp_schema, register_tools
+from ace.integrations.mcp.config import MCPServerConfig
+from ace.integrations.mcp.errors import (
+    ForbiddenInSafeModeError,
+    SessionNotFoundError,
+    ValidationError as ACEValidationError,
+    map_error_to_mcp,
+)
+from ace.integrations.mcp.handlers import MCPHandlers
+from ace.integrations.mcp.models import AskRequest, LearnSampleRequest
+from ace.integrations.mcp.registry import SessionRegistry
+from ace.integrations.mcp.server import _MCP_INSTALL_HINT as SERVER_INSTALL_HINT
+
+
+_CLIENT_PATTERN = re.compile(
+    r"(vs\s*code|vscode|visual\s*studio\s*code|cursor|windsurf)",
+    re.IGNORECASE,
+)
+
+
+def _require_mcp():
+    pytest.importorskip("mcp.server")
+    pytest.importorskip("mcp.types")
+
+    from mcp.server import Server
+    from mcp.types import CallToolRequest, ListToolsRequest
+
+    return Server, CallToolRequest, ListToolsRequest
+
+
+def test_ask_request_schema_is_inlined():
+    schema = _mcp_schema(AskRequest)
+    schema_str = json.dumps(schema)
+
+    assert "$ref" not in schema_str
+    assert "$defs" not in schema_str
+    assert "session_id" in schema.get("properties", {})
+    assert "question" in schema.get("properties", {})
+
+
+def test_nested_schema_is_inlined():
+    schema = _mcp_schema(LearnSampleRequest)
+    schema_str = json.dumps(schema)
+
+    assert "$ref" not in schema_str
+    assert "$defs" not in schema_str
+    assert "samples" in schema.get("properties", {})
+
+
+def test_install_hints_are_client_agnostic():
+    assert not _CLIENT_PATTERN.search(SERVER_INSTALL_HINT)
+    assert not _CLIENT_PATTERN.search(ADAPTERS_INSTALL_HINT)
+
+
+def test_error_messages_are_client_agnostic():
+    for err in (
+        SessionNotFoundError("session-1"),
+        ForbiddenInSafeModeError("ace.learn.sample"),
+        ACEValidationError("prompt too long", details={"field": "question"}),
+        RuntimeError("boom"),
+    ):
+        mapped = map_error_to_mcp(err)
+        assert not _CLIENT_PATTERN.search(mapped["message"])
+
+
+@pytest.fixture
+def wired_server():
+    Server, _, _ = _require_mcp()
+
+    config = MCPServerConfig(safe_mode=False)
+    registry = SessionRegistry(config)
+    handlers = MCPHandlers(registry, config)
+    server = Server("ace-mcp-server")
+    register_tools(server, handlers)
+    return server, registry
+
+
+@pytest.mark.asyncio
+async def test_published_tool_schemas_are_inlined(wired_server):
+    server, _ = wired_server
+    _, _, ListToolsRequest = _require_mcp()
+
+    handler = server.request_handlers.get(ListToolsRequest)
+    assert handler is not None
+
+    result = await handler(MagicMock())
+    for tool in result.root.tools:
+        schema_str = json.dumps(tool.inputSchema)
+        assert "$ref" not in schema_str
+        assert "$defs" not in schema_str
+        assert not _CLIENT_PATTERN.search(tool.description or "")
+
+
+@pytest.mark.asyncio
+async def test_call_tool_ace_ask_returns_json_payload(wired_server):
+    server, _ = wired_server
+    _, CallToolRequest, _ = _require_mcp()
+
+    with patch("ace.integrations.mcp.registry.ACELiteLLM") as mock_runner_cls:
+        runner = MagicMock()
+        runner.ask.return_value = "The answer is 42."
+        runner.skillbook.skills.return_value = []
+        mock_runner_cls.from_model.return_value = runner
+
+        handler = server.request_handlers.get(CallToolRequest)
+        assert handler is not None
+
+        req = MagicMock()
+        req.params.name = "ace.ask"
+        req.params.arguments = {
+            "session_id": "generic-client-1",
+            "question": "What is the meaning of life?",
+        }
+
+        result = await handler(req)
+        assert not result.root.isError
+
+        payload = json.loads(result.root.content[0].text)
+        assert payload["answer"] == "The answer is 42."
+        assert payload["session_id"] == "generic-client-1"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_unknown_tool_returns_structured_error(wired_server):
+    server, _ = wired_server
+    _, CallToolRequest, _ = _require_mcp()
+
+    handler = server.request_handlers.get(CallToolRequest)
+    assert handler is not None
+
+    req = MagicMock()
+    req.params.name = "nonexistent.tool"
+    req.params.arguments = {}
+
+    result = await handler(req)
+    assert result.root.isError
+
+    payload = json.loads(result.root.content[0].text)
+    assert payload["code"] == "ACE_MCP_INTERNAL_ERROR"
+    assert "Unknown tool" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_session_ids_are_opaque_strings():
+    config = MCPServerConfig()
+    registry = SessionRegistry(config)
+
+    with patch("ace.integrations.mcp.registry.ACELiteLLM") as mock_runner_cls:
+        mock_runner_cls.from_model.side_effect = lambda *a, **kw: MagicMock()
+
+        ids = [
+            "simple-id",
+            "uuid-550e8400-e29b-41d4-a716-446655440000",
+            "cursor/project/session-1",
+            "claude-code:workspace:12345",
+        ]
+
+        sessions = [await registry.get_or_create(session_id) for session_id in ids]
+
+        assert [session.session_id for session in sessions] == ids
+        assert len({id(session.runner) for session in sessions}) == len(ids)


### PR DESCRIPTION
## Summary

- add a client setup guide for ACE MCP covering Claude Code, Cursor, Windsurf, and Inspector smoke testing
- link the new guide from the MCP docs, integrations overview, and MkDocs nav
- add focused MCP compatibility tests for schema inlining, generic `call_tool` behavior, client-agnostic messaging, and opaque session IDs

## Testing

- `uv run --extra mcp pytest tests/test_ace_mcp_server.py tests/test_ace_mcp_handlers.py tests/test_ace_mcp_registry.py tests/test_ace_mcp_compatibility.py`