### PR TITLE
feat(tracing): TS SDK session/user metadata API (0.10.0)

### DIFF
--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,17 +1,15 @@
 {
-  "name": "@kayba/tracing",
-  "version": "0.1.0",
+  "name": "@kayba_ai/tracing",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@kayba/tracing",
-      "version": "0.1.0",
+      "name": "@kayba_ai/tracing",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "dotenv": "^17.4.1",
-        "mlflow-tracing": "^0.1.0",
-        "openai": "^6.34.0"
+        "mlflow-tracing": "^0.1.0"
       },
       "devDependencies": {
         "tsup": "^8.0.0",
@@ -1721,18 +1719,6 @@
         }
       }
     },
-    "node_modules/dotenv": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
-      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -2238,27 +2224,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/openai": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.34.0.tgz",
-      "integrity": "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/path-parse": {

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kayba_ai/tracing",
-  "version": "0.9.7",
+  "version": "0.10.0",
   "description": "Kayba tracing SDK — instrument your AI agents and send traces to Kayba",
   "license": "MIT",
   "author": "Kayba.ai <hello@kayba.ai>",

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -42,6 +42,8 @@ const HTML_TAG_RE = /<[^>]*>/g;
 // ── Module state ───────────────────────────────────────────────────────
 
 let _folder: string | null = null;
+let _sessionId: string | null = null;
+let _userId: string | null = null;
 let _configured = false;
 
 // ── Types ──────────────────────────────────────────────────────────────
@@ -95,13 +97,25 @@ function resolveFolder(
   return sanitized || null;
 }
 
-function injectFolderTag(): void {
-  if (_folder !== null) {
-    try {
-      updateCurrentTrace({ tags: { "kayba.folder": _folder } });
-    } catch {
-      // Silently ignore if no active trace context.
-    }
+function injectKaybaContext(): void {
+  const tags: Record<string, string> = {};
+  const metadata: Record<string, string> = {};
+
+  if (_folder !== null) tags["kayba.folder"] = _folder;
+  if (_sessionId !== null) metadata["mlflow.trace.session"] = _sessionId;
+  if (_userId !== null) metadata["mlflow.trace.user"] = _userId;
+
+  const hasTags = Object.keys(tags).length > 0;
+  const hasMetadata = Object.keys(metadata).length > 0;
+  if (!hasTags && !hasMetadata) return;
+
+  try {
+    const update: { tags?: Record<string, string>; metadata?: Record<string, string> } = {};
+    if (hasTags) update.tags = tags;
+    if (hasMetadata) update.metadata = metadata;
+    updateCurrentTrace(update);
+  } catch {
+    // Silently ignore if no active trace context.
   }
 }
 
@@ -160,6 +174,55 @@ export function getFolder(): string | null {
 }
 
 /**
+ * Set the session id auto-injected as `mlflow.trace.session` metadata on
+ * every subsequent trace. Use this to group multiple traces (e.g. each
+ * tool call producing its own trace) into a single agent run / conversation.
+ *
+ * @param sessionId - Session id, or `null` to clear.
+ */
+export function setSession(sessionId: string | null): void {
+  _sessionId = sessionId && sessionId.length > 0 ? sessionId : null;
+}
+
+/** Return the currently configured session id, or `null`. */
+export function getSession(): string | null {
+  return _sessionId;
+}
+
+/**
+ * Set the user id auto-injected as `mlflow.trace.user` metadata on every
+ * subsequent trace.
+ *
+ * @param userId - User id, or `null` to clear.
+ */
+export function setUser(userId: string | null): void {
+  _userId = userId && userId.length > 0 ? userId : null;
+}
+
+/** Return the currently configured user id, or `null`. */
+export function getUser(): string | null {
+  return _userId;
+}
+
+/**
+ * Attach tags and/or metadata to the currently active trace. Use this for
+ * per-call values like a tool call id. Folder, session, and user are
+ * auto-injected — call this only for additional fields.
+ *
+ * Silently no-ops when called outside an active trace context.
+ */
+export function updateTrace(update: {
+  tags?: Record<string, string>;
+  metadata?: Record<string, string>;
+}): void {
+  try {
+    updateCurrentTrace(update);
+  } catch {
+    // Silently ignore if no active trace context.
+  }
+}
+
+/**
  * Wrap a function with tracing. The returned function generates a span
  * each time it is called, with automatic folder tagging.
  *
@@ -181,12 +244,12 @@ export function trace<T extends (...args: any[]) => any>(
     // Handle async functions: inject tag after the promise resolves.
     if (result instanceof Promise) {
       return result.then((value: unknown) => {
-        injectFolderTag();
+        injectKaybaContext();
         return value;
       }) as ReturnType<T>;
     }
 
-    injectFolderTag();
+    injectKaybaContext();
     return result;
   };
 
@@ -222,7 +285,7 @@ export function startSpan(options: StartSpanOptions) {
   // Wrap .end() to inject the folder tag before closing.
   const originalEnd = span.end.bind(span);
   span.end = (endOptions?: Parameters<typeof span.end>[0]) => {
-    injectFolderTag();
+    injectKaybaContext();
     return originalEnd(endOptions);
   };
 
@@ -247,6 +310,11 @@ const kayba = {
   startSpan,
   setFolder,
   getFolder,
+  setSession,
+  getSession,
+  setUser,
+  getUser,
+  updateTrace,
   isConfigured,
   SpanType,
 };


### PR DESCRIPTION
## Summary
- Adds `setSession`, `setUser`, and `updateTrace` to `@kayba_ai/tracing` so callers can group multiple traces into a single agent run via `mlflow.trace.session` and `mlflow.trace.user` metadata.
- Internal `injectFolderTag` renamed to `injectKaybaContext`, now emits folder + session + user in one `updateCurrentTrace` call.
- Lockfile rewrite corrects a pre-existing mismatch (was `@kayba/tracing@0.1.0` with stray `openai`/`dotenv`).
- Bumps SDK to `0.10.0` (additive, no breaking changes).

## Why
Each call to `kayba.trace(fn)` creates a new MLflow trace. Without a session id, agents that emit one trace per tool call (e.g. traderclaw plugin) leave 50+ disconnected traces in the dashboard with no way to filter them as a single conversation. This adds the standard MLflow `mlflow.trace.session` / `mlflow.trace.user` metadata, plus a generic `updateTrace` escape hatch for per-call tags.

## Test plan
- [x] tsc --noEmit clean
- [x] tsup build clean (cjs/esm/dts)
- [x] Verified consumer (traderclaw plugin) imports kayba.setSession / setUser / updateTrace and bundles cleanly via npm link
- [ ] After merge: cut release v0.10.0-ts to trigger publish-to-npm workflow