### PR TITLE
refactor(rr): cost-aware budget, Bedrock cache defaults, recurse-friendly prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,5 @@ node_modules/
 
 # Local scratch / experiment outputs
 tmp/
+
+spyfly-traces

--- a/ace/core/recursive_agent.py
+++ b/ace/core/recursive_agent.py
@@ -93,6 +93,11 @@ def register_execute_code(agent: PydanticAgent[AgenticDeps, Any]) -> None:
         Variables persist across calls. Pre-loaded modules:
         ``json``, ``re``, ``collections``, ``datetime``.
 
+        Built-in helper: ``register_helper(name, source, description)``
+        defines a reusable Python function in this sandbox AND auto-injects
+        it into every child you later spawn via ``recurse`` — register
+        extraction/scoring logic once, reuse it across children.
+
         Args:
             code: Python code to execute.
 
@@ -148,18 +153,24 @@ def register_recurse(agent: PydanticAgent[AgenticDeps, Any]) -> None:
         prompt: str,
         context_code: str = "",
     ) -> str:
-        """Spawn a child session to handle a sub-problem.
+        """Spawn a child session to investigate a sub-problem in isolation.
 
-        The child gets its own sandbox (inheriting data and helpers from
-        the parent) and a fraction of the remaining token budget.
+        Use this to keep your context lean: the child works through
+        bulky data in its own context window and returns only a text
+        summary. The child inherits a copy of your sandbox variables
+        and any helpers you've registered via `register_helper`. It
+        does NOT see your conversation, so `prompt` must be self-contained.
+        Calling `recurse` multiple times in a single assistant turn
+        dispatches the children in parallel.
 
         Args:
-            prompt: Instructions for the child session.
-            context_code: Optional Python code to prepare the child's
-                sandbox before the session starts.
+            prompt: Self-contained instructions. Name the sandbox
+                variables to inspect and say what to return.
+            context_code: Optional Python run once in the child's
+                sandbox before it starts (e.g. ``chunk = traces[5:10]``).
 
         Returns:
-            Text summary of the child session's output.
+            Text summary of the child's structured output.
         """
         deps = ctx.deps
         if deps.run_session_fn is None:
@@ -282,9 +293,9 @@ class AgenticConfig:
     usage_callback: UsageCallback | None = None
 
     def build_usage_limits(self, remaining_tokens: int | None = None) -> UsageLimits:
-        """Build PydanticAI UsageLimits from this config."""
+        base = remaining_tokens or self.max_tokens
         return UsageLimits(
-            total_tokens_limit=remaining_tokens or self.max_tokens,
+            total_tokens_limit=base,
             request_limit=self.max_requests,
         )
 
@@ -329,8 +340,42 @@ class BudgetExhausted(Exception):
 # ------------------------------------------------------------------
 
 
-def is_budget_exhausted(limits: UsageLimits, usage: Any) -> bool:
-    """True if total token/request budget is spent."""
+def cost_equivalent_tokens(usage: Any) -> int:
+    """Cost-equivalent token count for budget purposes.
+
+    Anthropic Bedrock pricing (input side):
+      - fresh:        1.0x base
+      - cache_write:  1.25x base
+      - cache_read:   0.10x base
+
+    PydanticAI's Bedrock wrapper sets ``input_tokens = fresh + cache_write +
+    cache_read``. We rebuild the cost-equivalent: subtract 0.90x of cache_read
+    (since it should weigh 0.10 not 1.0) and add 0.25x of cache_write (since
+    it should weigh 1.25 not 1.0). Output is counted at 1.0x.
+    """
+    input_tokens = getattr(usage, "input_tokens", 0) or 0
+    cache_read = getattr(usage, "cache_read_tokens", 0) or 0
+    cache_write = getattr(usage, "cache_write_tokens", 0) or 0
+    output = getattr(usage, "output_tokens", 0) or 0
+    cost_input = input_tokens - 0.90 * cache_read + 0.25 * cache_write
+    return int(cost_input + output)
+
+
+def is_budget_exhausted(
+    limits: UsageLimits,
+    usage: Any,
+    cost_budget: int | None = None,
+) -> bool:
+    """True if cost-equivalent or request budget is spent.
+
+    When ``cost_budget`` is provided, the *cost-equivalent* token count
+    (``cost_equivalent_tokens``) is checked against it. The gross
+    ``total_tokens_limit`` on ``limits`` is treated as a coarse outer cap and
+    is normally inflated relative to the real budget, so it should rarely
+    trip first when caching is in play.
+    """
+    if cost_budget is not None and cost_equivalent_tokens(usage) >= cost_budget:
+        return True
     if limits.total_tokens_limit and usage.total_tokens >= limits.total_tokens_limit:
         return True
     if limits.request_limit and usage.requests >= limits.request_limit:
@@ -477,7 +522,11 @@ async def run_agent_with_compaction(
                 messages = last_run.all_messages()
                 cumulative_usage = last_run.usage()
 
-                if is_budget_exhausted(usage_limits, cumulative_usage):
+                if is_budget_exhausted(
+                    usage_limits,
+                    cumulative_usage,
+                    cost_budget=config.max_tokens,
+                ):
                     raise BudgetExhausted(
                         compaction_count=compaction_count,
                         usage=cumulative_usage,
@@ -600,7 +649,13 @@ class RecursiveAgent:
         self._agent = self._create_agent(depth=0)
 
     def _create_agent(self, depth: int = 0) -> PydanticAgent[AgenticDeps, Any]:
-        """Create a PydanticAI agent for the given recursion depth."""
+        """Create a PydanticAI agent for the given recursion depth.
+
+        The root (depth 0) uses the configured ``output_type`` (typically
+        a structured Pydantic model). Children return free-form text:
+        they exist to investigate one sub-problem and report a focused
+        answer, not to produce a full reflection.
+        """
         if isinstance(self._model, PydanticModel):
             resolved = self._model
         else:
@@ -609,9 +664,11 @@ class RecursiveAgent:
         if self.config.usage_callback is not None:
             resolved = MeteredModel(resolved, self.config.usage_callback)
 
+        output_type = self._output_type if depth == 0 else str
+
         agent: PydanticAgent[AgenticDeps, Any] = PydanticAgent(
             resolved,
-            output_type=self._output_type,
+            output_type=output_type,
             system_prompt=self._system_prompt,
             retries=3,
             model_settings=self._model_settings,

--- a/ace/implementations/prompts.py
+++ b/ace/implementations/prompts.py
@@ -517,6 +517,7 @@ Skills rendered into the agent's prompt this run (tagging scope):
 </task_context>
 
 <workflow>
+0. Check `stats.skills` above. If it's 0, skip every `search_skills` / `read_skill` call — there is nothing to find.
 1. Read the reflection. Identify concrete patterns with evidence.
 2. Tag only the skills the reflection provides direct evidence for — that is, \
 skills the reflection actually implicates (cites, contradicts, builds on, or \

--- a/ace/implementations/rr/prompts.py
+++ b/ace/implementations/rr/prompts.py
@@ -7,22 +7,29 @@ sub-problems. Conclusions live only in the final ReflectorOutput.
 """
 
 REFLECTOR_RECURSIVE_SYSTEM = """\
-You analyze agent execution traces and extract learnings that become strategies for future agents.
+You are a recursive agent that analyze agent execution traces and extract learnings that become strategies for future agents.
 
-Use `execute_code` as a Python workbench to inspect traces, define reusable variables, and verify claims.
-Use `think` to narrate your working state — what you just confirmed, what you're checking next, brief observations. This keeps prose out of Python stdout.
-Use `recurse` to decompose large or complex sub-problems.
+## Tools
+- `execute_code(code)` — Python workbench. Variables persist across calls. Pre-loaded: `json`, `re`, `collections`, `datetime`. Built-in helper: `register_helper(name, source, description)` defines a function that persists here AND is auto-injected into every `recurse` child you later spawn. **If the same logic would be useful in multiple children, `register_helper` it ONCE — do not re-paste the same code into each child's `context_code`.**
+- `think(thought)` — narrate your working state (what you just confirmed, what's next). Keeps prose out of Python stdout.
+- `recurse(prompt, context_code?)` — spawn a child session in its own context window. Child inherits a copy of your sandbox **values** (lists, dicts, strings, numbers) plus any `register_helper`-registered helpers; it does NOT inherit plain `def` functions and does NOT see your conversation, so `prompt` must be self-contained. To give a child a function, either `register_helper(...)` it (persists for all future children) or paste the `def` into the child's `context_code` (one-off, exec'd in the child sandbox before its session starts). Children themselves may call `recurse` further as long as the tool appears in their tool list (max-depth gated). Multiple `recurse` calls in one assistant turn dispatch in parallel.
+ - `search_skillbook(query, top_k)` / `read_skill(skill_id)` — inspect the skillbook (skip when empty).
 
-When you have enough evidence, stop using tools and return the final ReflectorOutput. Conclusions, root cause, and key insight live there."""
+## Working rules
+- `execute_code` carries DATA (parse, filter, slice, print compact dicts/counts). `think` carries NARRATION. The final `ReflectorOutput` is the only sink that propagates downstream — conclusions live ONLY there, never in print statements.
+- **Minimize turns.** Every turn replays the full conversation, so each tool call costs more than the last. Batch independent reads in one turn (parallel `execute_code` / `recurse` calls). Plan a small number of high-yield steps. Stop as soon as you have enough — do NOT keep verifying just because budget remains.
+- When you write a `recurse` prompt: ONE deliverable, name the sandbox variables the child should inspect, state the return shape. Do NOT dump multi-question task lists onto a child. **Pre-extract the data the child needs into flat sandbox variables yourself** (e.g. `tool_calls_per_turn = {{...}}`) — don't make the child re-parse raw structure you already understand.
+- **Fan out when your task decomposes.** If your work contains numbered sub-questions (1, 2, 3, …) or asks for the same extraction across N items, that IS a decomposition — dispatch N parallel `recurse` calls in ONE assistant turn instead of walking serially. Applies at any depth: don't bundle independent sub-tasks into a single mega-child.
+- When you have enough evidence, stop using tools and return your final answer (root sessions return a structured `ReflectorOutput`; child sessions return free-form text answering exactly what their prompt asked for — no JSON schema, just the result)."""
 
 
 REFLECTOR_RECURSIVE_PROMPT = """\
 <purpose>
-You analyze an agent's execution trace to extract learnings for a **skillbook** — strategies
+You a recursive agent which analyze an agent's execution trace to extract learnings for a **skillbook** — strategies
 injected into future agents' prompts. Identify WHAT the agent did that mattered and WHY.
 
-The trace shape is whatever was given to you — it varies. Use `execute_code` to discover
-its structure if you don't already know it; do not assume specific keys or fields exist.
+The trace shape is whatever was given to you — it varies. Use `execute_code` to discover.
+Use `recurse` to fan-out the work to sub-agents.
 </purpose>
 
 <sandbox>
@@ -52,8 +59,6 @@ Three channels, three jobs:
 - **`think` carries your running narration.** "Numbers look off — checking the breakdown next." "Mismatch confirmed; one more cross-check and I'm done." "This branch is a side path, focusing on the main decision." Use it freely. It is the right home for everything you would naturally say while working.
 - **`ReflectorOutput`** is the only sink that propagates downstream. The final conclusion, root cause, correct approach, and key insight live there — and only there.
 
-Persistent state for handoff to a sub-`recurse` is a sandbox variable inside `execute_code`, not a `think` note.
-
 **Parallel tool calls.** When you have multiple independent things to check, issue them in a single turn instead of one-at-a-time. Examples: several `search_skillbook` queries with different angles, `read_skill` calls for a batch of IDs, independent `execute_code` reads of disjoint slices, or `recurse` calls dispatched into independent sub-investigations (the natural way to handle huge or batched inputs that need to be split). Don't parallelize calls that depend on each other or share variable writes.
 
 Bad — manually written report inside `execute_code`:
@@ -79,13 +84,35 @@ Then `think("primary check confirmed; investigating the secondary path next")`. 
 </sandbox>
 
 <strategy>
-Explore the trace via `execute_code`, store reusable state in sandbox variables, and verify the agent's claims against the data it received. Use `recurse` only when a sub-problem genuinely needs its own multi-step investigation. Synthesize the final reflection in the ReflectorOutput — not in print statements.
+Start by evaluating your startegy, how should you proceed?
+Try to find the important parts of the input and extract them, filter out the noise from the trace to reduce the size substantially. If clean trace, you can skip this, do this in the beginnning.
+**Minimize turns.** Every assistant turn replays the full conversation, so each `execute_code` call costs more than the last. Plan a small number of high-yield steps, batch independent reads in a single turn (parallel `execute_code` / `recurse` / `search_skillbook` calls), and stop once you have enough evidence — do NOT keep verifying just because budget remains.
+
+Explore the trace via `execute_code`, store reusable state in sandbox variables, and verify the agent's claims against the data it received. 
+
+IMPORTANT: Use `recurse` when the input trace is too large (more than roughly 400k chars) or sub-problem needs its own multi-step investigation. This will allow to fan-out the work and make it scalable.
+YOU MUST USE SUB AGENTS EXTENSIVELY USING RECURSE EARLY ON, REDUCING CONTEXT WINDOW SIZE.
+
+`register_helper(...)` any extractor functions you'll want to reuse — plain `def` is NOT inherited by children, registered helpers ARE.
+Compute a flat `briefing` dict/list with the pre-extracted slices the child actually needs. Don't make the child re-parse raw structure you already understand.
+Built-in helper inside `execute_code`: `register_helper(name, source, description)` defines a Python function that persists in this sandbox AND is auto-injected into every child you later spawn via `recurse`.
+
+*Recurse call:* the child sees nothing of your conversation, so the prompt is self-contained:
+    **One question** — what is the child answering? (e.g. "Identify which turns had empty LLM outputs and what triggered them."). 
+    **Instructions** — Use clear instructions if needed to steer behavior
+    **Inputs** — name the sandbox variables (e.g. `briefing`) and the registered helpers the child should use (e.g. `extract_llm_data`).
+    **Method hint (optional)** — a one-line nudge if the approach isn't obvious.
+    **Return shape** — exactly what to put back (e.g. "Return a list of `{{turn_idx, trigger, prompt_excerpt}}` dicts.")
+    **Hand off Context** — Any additional context that could be useful to get the task done faster
+
+**Name what you find.** Whenever you discover or compute something useful (a slice, a count, a parsed structure), assign it to a named sandbox variable instead of just printing it. Use distinctive names you'll remember across many turns.
+To list the current sandbox vars: `print([k for k in dir() if not k.startswith('_') and k not in ('json','re','collections','datetime')])`.
 
 Even when the agent's run looks like a clean win, there are still lessons. Look for both:
 - **Success patterns** — concrete behavior the agent used that produced the result. These are transferable strategies for future agents to replicate.
 - **Subtle deviations** — places the agent did something wrong along the way, even if it didn't break the final outcome. These are still failure-mode lessons.
 
-**Skim the skillbook early.** Run `search_skillbook` queries at the *start* of your investigation — for the topic of the trace, the kind of error you suspect, and the agent's apparent strategy. This tells you what's already known and lets you frame the agent's behavior against existing skills as you analyze, not after. Repeat searches as new hypotheses form. In `reasoning`, explicitly call out the relationship between the agent's behavior and the skillbook:
+**Skim the skillbook early.** If `skillbook_length` above is 0, the skillbook is empty — **do not call `search_skillbook` or `read_skill` at all**, there is nothing to find. Otherwise run `search_skillbook` queries at the *start* of your investigation — for the topic of the trace, the kind of error you suspect, and the agent's apparent strategy. This tells you what's already known and lets you frame the agent's behavior against existing skills as you analyze, not after. Repeat searches as new hypotheses form. In `reasoning`, explicitly call out the relationship between the agent's behavior and the skillbook:
 - **Skill that failed to prevent the mistake**: an existing skill already covers this lesson, yet the agent still made the error. Useful signal that the skill needs sharpening, repositioning, or stronger emphasis.
 - **Skill that may have caused the mistake**: a skill the agent had access to may have nudged it toward the wrong behavior. Useful signal that the skill is misleading or being misapplied.
 - **Overlap or contradiction**: the lesson you're proposing already exists, partially exists, or contradicts an existing skill.

--- a/ace/implementations/rr/tools.py
+++ b/ace/implementations/rr/tools.py
@@ -58,8 +58,7 @@ def register_output_validator(agent: "PydanticAgent[RRDeps, Any]") -> None:
         if ctx.deps.iteration < 1:
             raise ModelRetry(
                 "You haven't explored the data enough. "
-                "Use execute_code first, "
-                "then provide your final ReflectorOutput."
+                "Use execute_code first, then provide your final answer."
             )
         return output
 

--- a/ace/implementations/skill_manager.py
+++ b/ace/implementations/skill_manager.py
@@ -103,6 +103,15 @@ class SkillManager(RecursiveAgent):
     ) -> None:
         self._prompt_template = prompt_template
 
+        if model_settings is None:
+            from pydantic_ai.models.bedrock import BedrockModelSettings
+
+            model_settings = BedrockModelSettings(
+                bedrock_cache_instructions=True,
+                bedrock_cache_tool_definitions=True,
+                bedrock_cache_messages=True,
+            )
+
         super().__init__(
             model,
             output_type=SkillManagerReport,

--- a/ace/steps/rr_step.py
+++ b/ace/steps/rr_step.py
@@ -80,7 +80,18 @@ class RRStep(RecursiveAgent):
         model_settings: ModelSettings | None = None,
     ) -> None:
         self.prompt_template = prompt_template
-        effective_model_settings = model_settings or ModelSettings(temperature=0.0)
+        effective_model_settings: ModelSettings
+        if model_settings is None:
+            from pydantic_ai.models.bedrock import BedrockModelSettings
+
+            effective_model_settings = BedrockModelSettings(
+                temperature=0.0,
+                bedrock_cache_instructions=True,
+                bedrock_cache_tool_definitions=True,
+                bedrock_cache_messages=True,
+            )
+        else:
+            effective_model_settings = model_settings
 
         super().__init__(
             model,

--- a/sdk/typescript/example.ts
+++ b/sdk/typescript/example.ts
@@ -1,0 +1,115 @@
+/**
+ * Example: instrument a GLM agent pipeline with Kayba tracing (TypeScript).
+ *
+ * Mirrors the Python example in examples/tracing_glm_example.py.
+ *
+ * Run: npx tsx example.ts
+ */
+
+import "dotenv/config";
+import OpenAI from "openai";
+import kayba, { SpanType } from "./src/index";
+
+// ── Kayba tracing setup ────────────────────────────────────────────────
+kayba.configure({
+  apiKey: process.env.KAYBA_SDK_KEY,
+  baseUrl: process.env.KAYBA_BASE_URL,
+  folder: "ts-sdk-examples",
+});
+
+// ── OpenAI client (GLM-compatible endpoint) ────────────────────────────
+const client = new OpenAI({
+  baseUrl: process.env.OPENAI_BASE_URL,
+  apiKey: process.env.OPENAI_API_KEY,
+});
+const MODEL = "glm-5.1";
+
+// ── Traced helper functions ────────────────────────────────────────────
+
+const llmCall = kayba.trace(
+  async (messages: OpenAI.ChatCompletionMessageParam[]) => {
+    const response = await client.chat.completions.create({
+      model: MODEL,
+      messages,
+      temperature: 0.7,
+    });
+    return response.choices[0].message.content ?? "";
+  },
+  { name: "llm_call", spanType: SpanType.LLM },
+);
+
+const researchAgent = kayba.trace(
+  async (topic: string) => {
+    const span = kayba.startSpan({
+      name: "build_prompt",
+      spanType: SpanType.TOOL,
+      inputs: { topic },
+    });
+
+    const messages: OpenAI.ChatCompletionMessageParam[] = [
+      {
+        role: "system",
+        content: "You are a research assistant. List 3 key facts.",
+      },
+      { role: "user", content: `Research this topic: ${topic}` },
+    ];
+
+    span.end({ outputs: { message_count: messages.length }, status: "OK" });
+
+    return await llmCall(messages);
+  },
+  { name: "research_agent", spanType: SpanType.AGENT },
+);
+
+const summariserAgent = kayba.trace(
+  async (facts: string) => {
+    const span = kayba.startSpan({
+      name: "build_prompt",
+      spanType: SpanType.TOOL,
+      inputs: { facts_length: facts.length },
+    });
+
+    const messages: OpenAI.ChatCompletionMessageParam[] = [
+      {
+        role: "system",
+        content:
+          "You are a summariser. Condense the following facts into one concise paragraph.",
+      },
+      { role: "user", content: facts },
+    ];
+
+    span.end({ outputs: { message_count: messages.length }, status: "OK" });
+
+    return await llmCall(messages);
+  },
+  { name: "summariser_agent", spanType: SpanType.AGENT },
+);
+
+const runPipeline = kayba.trace(
+  async (topic: string) => {
+    const facts = await researchAgent(topic);
+    console.log(`\n--- Research Agent ---\n${facts}`);
+
+    const summary = await summariserAgent(facts);
+    console.log(`\n--- Summariser Agent ---\n${summary}`);
+
+    return summary;
+  },
+  { name: "pipeline", spanType: SpanType.CHAIN },
+);
+
+// ── Main ───────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("Running TypeScript tracing example...\n");
+
+  const result = await runPipeline("The history of the Silk Road");
+  console.log(`\n--- Final result ---\n${result}`);
+
+  // Give MLflow time to flush traces to Kayba
+  console.log("\nFlushing traces...");
+  await new Promise((r) => setTimeout(r, 3000));
+  console.log("Done!");
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- **Budget**: cost-equivalent token accounting in `is_budget_exhausted` (Bedrock pricing: cache_read ×0.10, cache_write ×1.25, fresh ×1.0); compaction loop now budgets on cost.
- **Caching defaults**: `RRStep` and `SkillManager` default to `BedrockModelSettings` with instructions/tool-defs/messages caching enabled.
- **Recursive output shape**: children return free-form `str`; only the root agent keeps the structured `output_type`.
- **Reflector prompts** rewritten to push fan-out via `recurse` + `register_helper`, minimize turns, and short-circuit skillbook lookups when empty.
- **SkillManager workflow** skips `search_skills`/`read_skill` when `stats.skills == 0`.
- **Tools**: output-validator retry message no longer assumes `ReflectorOutput`.
- **SDK**: add TypeScript tracing example (`sdk/typescript/example.ts`).
- **Misc**: bump `ace-eval` submodule; ignore `spyfly-traces`.

## Test plan
- [ ] `uv run pytest -m unit`
- [ ] Smoke-run an RR reflection end-to-end on a sample trace and confirm Bedrock cache hits show up in usage callback
- [ ] Verify `is_budget_exhausted` math against a known Bedrock usage payload
- [ ] Run `sdk/typescript/example.ts` against a Kayba project and confirm traces land