### PR TITLE
docs(browser-use): use installed model adapter

### DIFF
--- a/ace/runners/browser_use.py
+++ b/ace/runners/browser_use.py
@@ -39,6 +39,8 @@ class BrowserUse(ACERunner):
 
     Example::
 
+        from browser_use import ChatOpenAI
+
         runner = BrowserUse.from_model(
             browser_llm=ChatOpenAI(model="gpt-4o"),
             ace_model="gpt-4o-mini",

--- a/docs/concepts/insight-levels.md
+++ b/docs/concepts/insight-levels.md
@@ -54,6 +54,7 @@ Use when wrapping external agents where you don't have labeled answers.
 
 ```python
 from ace import BrowserUse
+from browser_use import ChatOpenAI
 
 # The browser-use agent produces a rich trace of actions
 runner = BrowserUse.from_model(

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -84,6 +84,7 @@ Three steps: **INJECT** skillbook context, **EXECUTE** with external agent, **LE
 
 ```python
 from ace import BrowserUse
+from browser_use import ChatOpenAI
 
 runner = BrowserUse.from_model(
     browser_llm=ChatOpenAI(model="gpt-4o"),

--- a/docs/design/ACE_REFERENCE.md
+++ b/docs/design/ACE_REFERENCE.md
@@ -982,7 +982,7 @@ results = ace.run(samples, epochs=3)
 
 ```python
 from ace import BrowserUse, Reflector, SkillManager
-from langchain_openai import ChatOpenAI
+from browser_use import ChatOpenAI
 
 browser_llm = ChatOpenAI(model="gpt-4o")
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -59,7 +59,7 @@ agent = ACELiteLLM.from_model("gpt-4o-mini")
 
     ```python
     from ace import BrowserUse
-    from langchain_openai import ChatOpenAI
+    from browser_use import ChatOpenAI
 
     runner = BrowserUse.from_model(
         browser_llm=ChatOpenAI(model="gpt-4o"),

--- a/docs/guides/integration.md
+++ b/docs/guides/integration.md
@@ -25,7 +25,7 @@ ACE provides runners for popular frameworks. Each uses `from_model()` for quick 
 
     ```python
     from ace import BrowserUse
-    from langchain_openai import ChatOpenAI
+    from browser_use import ChatOpenAI
 
     runner = BrowserUse.from_model(
         browser_llm=ChatOpenAI(model="gpt-4o"),

--- a/docs/integrations/browser-use.md
+++ b/docs/integrations/browser-use.md
@@ -12,7 +12,7 @@ uv add ace-framework[browser-use]
 
 ```python
 from ace import BrowserUse
-from langchain_openai import ChatOpenAI
+from browser_use import ChatOpenAI
 
 runner = BrowserUse.from_model(
     browser_llm=ChatOpenAI(model="gpt-4o"),
@@ -84,7 +84,7 @@ results = runner.run([
 
 ```python
 from ace import BrowserUse
-from langchain_openai import ChatOpenAI
+from browser_use import ChatOpenAI
 
 runner = BrowserUse.from_model(
     browser_llm=ChatOpenAI(model="gpt-4o"),


### PR DESCRIPTION
## What changed

- Use `browser_use.ChatOpenAI` in the seven Browser Use examples and the runner docstring.
- Keep the LangChain-specific example on `langchain_openai.ChatOpenAI`.

## Why

`uv add 'ace-framework[browser-use]'` installs Browser Use but not `langchain-openai`. The current quickstart imports `langchain_openai`, so a fresh install stops with `ModuleNotFoundError`. Browser Use already exports `ChatOpenAI`, so the examples can use the adapter the documented install provides.

This changes docs and a docstring only.

## Checks

- Fresh isolated `.[browser-use]` install: `langchain_openai` absent and its import reproduces `ModuleNotFoundError`
- `browser_use.ChatOpenAI` plus `browser_use.Agent` construction smoke, with no network call: passed
- `uv run pytest tests/test_ace_runners.py -q`: 22 passed
- `uv run black --check ace/runners/browser_use.py`: passed
- `git diff --check`: passed