### PR TITLE
fix(browser-use): preserve semantic task failures

### DIFF
--- a/ace/integrations/browser_use.py
+++ b/ace/integrations/browser_use.py
@@ -95,7 +95,7 @@ class BrowserExecuteStep:
         try:
             agent = Agent(**agent_params)
             history = await agent.run()
-            success = True
+            success = history.is_successful() is True
         except Exception as exc:
             error = str(exc)
 

--- a/docs/design/ACE_REFERENCE.md
+++ b/docs/design/ACE_REFERENCE.md
@@ -772,7 +772,8 @@ class BrowserExecuteStep:
         history = await agent.run()
 
         result = BrowserResult(
-            task=task, success=True, output=history.final_result(),
+            task=task, success=history.is_successful() is True,
+            output=history.final_result(),
             steps_count=history.number_of_steps(),
             chronological_steps=..., raw_history=history,
         )

--- a/docs/integrations/browser-use.md
+++ b/docs/integrations/browser-use.md
@@ -68,7 +68,7 @@ The extracted trace includes:
 - Agent reasoning at each step
 - Browser actions taken (click, type, navigate)
 - Page observations
-- Success/failure of each action
+- Success/failure of each action and the final browser task
 
 ## Running Multiple Tasks
 

--- a/tests/test_browser_use_integration.py
+++ b/tests/test_browser_use_integration.py
@@ -1,0 +1,61 @@
+"""Tests for the browser-use integration steps."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ace.core.context import ACEStepContext
+from ace.integrations import browser_use as browser_use_integration
+
+
+class FakeHistory:
+    """Small AgentHistoryList stand-in for semantic outcome tests."""
+
+    def __init__(self, semantic_success: bool | None) -> None:
+        self.semantic_success = semantic_success
+        self.history: list[Any] = []
+
+    def is_successful(self) -> bool | None:
+        return self.semantic_success
+
+    def final_result(self) -> str:
+        return "partial browser output"
+
+    def number_of_steps(self) -> int:
+        return 2
+
+    def total_duration_seconds(self) -> float:
+        return 1.25
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("semantic_success", "expected_success"),
+    [(True, True), (False, False), (None, False)],
+)
+async def test_execute_step_uses_browser_task_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+    semantic_success: bool | None,
+    expected_success: bool,
+) -> None:
+    """A returned history is not proof that the browser task succeeded."""
+
+    history = FakeHistory(semantic_success)
+
+    class FakeAgent:
+        def __init__(self, **_: Any) -> None:
+            pass
+
+        async def run(self) -> FakeHistory:
+            return history
+
+    monkeypatch.setattr(browser_use_integration, "BROWSER_USE_AVAILABLE", True)
+    monkeypatch.setattr(browser_use_integration, "Agent", FakeAgent)
+
+    step = browser_use_integration.BrowserExecuteStep(browser_llm=object())
+    result_context = await step(ACEStepContext(sample="Find the top HN post"))
+
+    assert isinstance(result_context.trace, browser_use_integration.BrowserResult)
+    assert result_context.trace.success is expected_success


### PR DESCRIPTION
## Summary

- derive BrowserResult.success from Browser Use's semantic run outcome
- keep failed and unfinished histories out of the success path
- cover True, False, and None outcomes and update the integration docs

## Why

Agent.run returns history for completed, failed, and unfinished tasks. The integration currently sets success=True for every returned history, so BrowserToTrace can tell the learning loop that a failed browser task succeeded.

## Validation

- `uv run pytest -q` (513 passed, 1 skipped)
- `uv run mypy ace/`
- `uv run black --check ace/integrations/browser_use.py tests/test_browser_use_integration.py`
- `git diff --check`

The repository-wide Black check still reports five unchanged files on current main; all changed Python files pass.
