### PR TITLE
Replace retired Claude model ids and stop sending a rejected temperature

### DIFF
--- a/ace/cli/setup.py
+++ b/ace/cli/setup.py
@@ -301,7 +301,7 @@ def run_setup(directory: str | Path = ".") -> ACEModelConfig:
     # Step 1: Default model
     print(f"{BOLD}Step 1: Choose your model{RESET}")
     print()
-    _info("Examples: gpt-4o-mini, claude-sonnet-4-20250514, ollama/llama2")
+    _info("Examples: gpt-4o-mini, claude-sonnet-5, ollama/llama2")
     _info(f"Search models: {CYAN}ace models <query>{RESET}")
     print()
 

--- a/ace/integrations/claude_sdk.py
+++ b/ace/integrations/claude_sdk.py
@@ -10,7 +10,7 @@ Usage::
     from ace.steps import learning_tail
 
     steps = [
-        ClaudeSDKExecuteStep(model="claude-sonnet-4-20250514"),
+        ClaudeSDKExecuteStep(model="claude-sonnet-5"),
         ClaudeSDKToTrace(),
         *learning_tail(reflector, skill_manager, skillbook),
     ]
@@ -103,10 +103,10 @@ class _ClaudeSDKConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    model: str = Field(default="claude-sonnet-4-20250514", min_length=1)
+    model: str = Field(default="claude-sonnet-5", min_length=1)
     system_prompt: Optional[str] = None
     max_tokens: int = Field(default=4096, gt=0)
-    temperature: float = Field(default=0.0, ge=0.0, le=1.0)
+    temperature: Optional[float] = Field(default=None, ge=0.0, le=1.0)
     tools: Optional[List[Dict[str, Any]]] = None
     api_key: Optional[str] = None
     base_url: Optional[str] = None
@@ -192,7 +192,7 @@ class ClaudeSDKExecuteStep:
     Compose with the learning tail::
 
         steps = [
-            ClaudeSDKExecuteStep(model="claude-sonnet-4-20250514"),
+            ClaudeSDKExecuteStep(model="claude-sonnet-5"),
             ClaudeSDKToTrace(),
             *learning_tail(reflector, skill_manager, skillbook),
         ]
@@ -203,11 +203,11 @@ class ClaudeSDKExecuteStep:
 
     def __init__(
         self,
-        model: str = "claude-sonnet-4-20250514",
+        model: str = "claude-sonnet-5",
         *,
         system_prompt: Optional[str] = None,
         max_tokens: int = 4096,
-        temperature: float = 0.0,
+        temperature: Optional[float] = None,
         tools: Optional[List[Dict[str, Any]]] = None,
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
@@ -346,9 +346,10 @@ class ClaudeSDKExecuteStep:
         api_kwargs: Dict[str, Any] = {
             "model": self.model,
             "max_tokens": self.max_tokens,
-            "temperature": self.temperature,
             "messages": messages,
         }
+        if self.temperature is not None:
+            api_kwargs["temperature"] = self.temperature
         if system is not None:
             api_kwargs["system"] = system
         if self.tools:

--- a/ace/providers/registry.py
+++ b/ace/providers/registry.py
@@ -36,7 +36,7 @@ def _litellm():
 # Example model strings per provider (for user guidance in the CLI)
 PROVIDER_MODEL_EXAMPLES: dict[str, str] = {
     "openai": "gpt-4o-mini",
-    "anthropic": "claude-sonnet-4-20250514",
+    "anthropic": "claude-sonnet-5",
     "gemini": "gemini/gemini-2.0-flash",
     "deepseek": "deepseek/deepseek-chat",
     "groq": "groq/llama-3.1-70b",
@@ -144,7 +144,6 @@ def validate_connection(model: str, api_key: str | None = None) -> ValidationRes
         "model": model,
         "messages": [{"role": "user", "content": "Say 'ok'"}],
         "max_tokens": 3,
-        "temperature": 0.0,
         "timeout": 15,
     }
     if api_key:

--- a/ace/runners/litellm.py
+++ b/ace/runners/litellm.py
@@ -203,7 +203,7 @@ class ACELiteLLM:
 
             config = ACEModelConfig(
                 default=ModelConfig(model="gpt-4o-mini"),
-                agent=ModelConfig(model="claude-sonnet-4-20250514"),
+                agent=ModelConfig(model="claude-sonnet-5"),
             )
             ace = ACELiteLLM.from_config(config)
         """

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -105,7 +105,7 @@ from ace.integrations import ClaudeSDKExecuteStep, ClaudeSDKToTrace
 
 skillbook = Skillbook()
 pipe = Pipeline([
-    ClaudeSDKExecuteStep(model="claude-sonnet-4-20250514"),
+    ClaudeSDKExecuteStep(model="claude-sonnet-5"),
     ClaudeSDKToTrace(),
     *learning_tail(Reflector("gpt-4o-mini"), SkillManager("gpt-4o-mini"), skillbook),
 ])

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -15,7 +15,7 @@ ACE Setup
 
 Step 1: Choose your model
 
-  Examples: gpt-4o-mini, claude-sonnet-4-20250514, ollama/llama2
+  Examples: gpt-4o-mini, claude-sonnet-5, ollama/llama2
   Search models: ace models <query>
 
   Default model: gpt-4o-mini
@@ -29,10 +29,10 @@ Step 2: Role assignment
 
   Use this model for all roles? [Y/n]: n
 
-  Agent (executes tasks) [gpt-4o-mini]: claude-sonnet-4-20250514
+  Agent (executes tasks) [gpt-4o-mini]: claude-sonnet-5
   ! No credentials found for anthropic
   ANTHROPIC_API_KEY: sk-ant-...
-  v Connected! (claude-sonnet-4-20250514 via anthropic, 347ms)
+  v Connected! (claude-sonnet-5 via anthropic, 347ms)
   v Saved credentials to .env
 
   Reflector (analyses results) [gpt-4o-mini]:
@@ -42,7 +42,7 @@ v Saved model config to ace.toml
 
   Configuration summary:
     default:        gpt-4o-mini
-    agent:          claude-sonnet-4-20250514
+    agent:          claude-sonnet-5
 ```
 
 The wizard tries the connection immediately — if your credentials are already in the environment (via `.env`, exported variables, or cloud auth like AWS), it just works. It only prompts for keys when the connection actually fails.
@@ -99,7 +99,7 @@ from ace import ACELiteLLM, ACEModelConfig, ModelConfig
 # Different models per role
 ace = ACELiteLLM.from_config(ACEModelConfig(
     default=ModelConfig(model="gpt-4o-mini"),
-    agent=ModelConfig(model="claude-sonnet-4-20250514"),
+    agent=ModelConfig(model="claude-sonnet-5"),
 ))
 ```
 
@@ -120,7 +120,7 @@ Example `ace.toml`:
 model = "gpt-4o-mini"
 
 [agent]
-model = "claude-sonnet-4-20250514"
+model = "claude-sonnet-5"
 max_tokens = 4096
 
 [reflector]
@@ -168,7 +168,7 @@ ACE uses [LiteLLM](https://docs.litellm.ai/) for model access. Any model string 
 | Provider | Model Example | Env Variable |
 |----------|--------------|--------------|
 | OpenAI | `gpt-4o-mini` | `OPENAI_API_KEY` |
-| Anthropic | `claude-sonnet-4-20250514` | `ANTHROPIC_API_KEY` |
+| Anthropic | `claude-sonnet-5` | `ANTHROPIC_API_KEY` |
 | AWS Bedrock | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` + `AWS_REGION_NAME` |
 | Google Gemini | `gemini/gemini-2.0-flash` | `GEMINI_API_KEY` |
 | DeepSeek | `deepseek/deepseek-chat` | `DEEPSEEK_API_KEY` |
@@ -203,8 +203,8 @@ The model string may have a typo. `ace validate` and `ace setup` suggest alterna
 ace validate claud-sonnet
 # x Model 'claud-sonnet' not found at the provider.
 # Did you mean:
-#   - claude-sonnet-4-20250514
-#   - claude-3-5-sonnet-20241022
+#   - claude-sonnet-5
+#   - claude-sonnet-4-5-20250929
 ```
 
 ### "Could not detect a provider"

--- a/docs/guides/integration.md
+++ b/docs/guides/integration.md
@@ -67,7 +67,7 @@ from ace.integrations import ClaudeSDKExecuteStep, ClaudeSDKToTrace
 
 skillbook = Skillbook()
 pipe = Pipeline([
-    ClaudeSDKExecuteStep(model="claude-sonnet-4-20250514"),
+    ClaudeSDKExecuteStep(model="claude-sonnet-5"),
     ClaudeSDKToTrace(),
     *learning_tail(Reflector("gpt-4o-mini"), SkillManager("gpt-4o-mini"), skillbook),
 ])

--- a/docs/integrations/claude-sdk.md
+++ b/docs/integrations/claude-sdk.md
@@ -13,7 +13,7 @@ from ace.integrations import ClaudeSDKExecuteStep, ClaudeSDKToTrace
 
 skillbook = Skillbook()
 pipe = Pipeline([
-    ClaudeSDKExecuteStep(model="claude-sonnet-4-20250514"),
+    ClaudeSDKExecuteStep(model="claude-sonnet-5"),
     ClaudeSDKToTrace(),
     *learning_tail(Reflector("gpt-4o-mini"), SkillManager("gpt-4o-mini"), skillbook),
 ])
@@ -53,10 +53,10 @@ configure_logfire()
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `model` | `str` | `"claude-sonnet-4-20250514"` | Claude model ID |
+| `model` | `str` | `"claude-sonnet-5"` | Claude model ID |
 | `system_prompt` | `str \| None` | `None` | Base system prompt |
 | `max_tokens` | `int` | `4096` | Maximum output tokens |
-| `temperature` | `float` | `0.0` | Sampling temperature |
+| `temperature` | `float \| None` | `None` | Sampling temperature. Left unset it is omitted from the request, so the API default applies. Sonnet 5 and Opus 5 reject any other value |
 | `tools` | `list[dict] \| None` | `None` | Anthropic tool definitions |
 | `api_key` | `str \| None` | `None` | Optional API key override |
 | `base_url` | `str \| None` | `None` | Optional API base URL |
@@ -98,7 +98,7 @@ tools = [
 ]
 
 execute = ClaudeSDKExecuteStep(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-5",
     tools=tools,
 )
 ```

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -55,7 +55,7 @@ from ace.integrations import ClaudeSDKExecuteStep, ClaudeSDKToTrace
 
 skillbook = Skillbook()
 pipe = Pipeline([
-    ClaudeSDKExecuteStep(model="claude-sonnet-4-20250514"),
+    ClaudeSDKExecuteStep(model="claude-sonnet-5"),
     ClaudeSDKToTrace(),
     *learning_tail(Reflector("gpt-4o-mini"), SkillManager("gpt-4o-mini"), skillbook),
 ])

--- a/tests/test_claude_sdk_step.py
+++ b/tests/test_claude_sdk_step.py
@@ -480,7 +480,7 @@ class TestClaudeSDKObservability:
         mock_logfire.span.assert_called_once()
         call_kwargs = mock_logfire.span.call_args
         assert call_kwargs[0][0] == "ClaudeSDKExecuteStep"
-        assert call_kwargs[1]["model"] == "claude-sonnet-4-20250514"
+        assert call_kwargs[1]["model"] == "claude-sonnet-5"
 
         # Attributes were set on the span
         attr_calls = {c[0][0]: c[0][1] for c in mock_span.set_attribute.call_args_list}


### PR DESCRIPTION
The Anthropic API retired `claude-sonnet-4-20250514` on 15 June 2026, and `claude-3-5-sonnet-20241022` before that. Both still appear here as the default model and in the setup docs, so a new user who follows `docs/getting-started/setup.md` picks an id the API no longer serves.

There is a second problem underneath the first one. Claude Sonnet 5 and Opus 5 accept only the default sampling temperature and reject any other value. `ClaudeSDKExecuteStep` puts `temperature` into every request and defaults it to `0.0`, and `validate_connection` pins the same `0.0` on its three-token probe. Swapping the model id alone would have moved the default path from "retired model" to "rejected parameter", so this PR handles both.

| File | Change |
|---|---|
| `ace/integrations/claude_sdk.py` | Default model to `claude-sonnet-5`. `temperature` is now `Optional[float]`, default `None`, and is added to the request only when a caller sets it |
| `ace/providers/registry.py` | Anthropic example id, and the `temperature: 0.0` removed from the connection probe |
| `ace/cli/setup.py` | Model example printed by the wizard |
| `ace/runners/litellm.py` | Docstring example |
| `docs/` | `getting-started/setup.md`, `integrations/claude-sdk.md`, `integrations/index.md`, `guides/integration.md`, `api/index.md` |
| `tests/test_claude_sdk_step.py` | One assertion that read the constructor default |

Callers who pass `temperature` explicitly keep the behaviour they have today, including the `0.0 <= t <= 1.0` validation. Only the unset case changed, and it changed from "send 0.0" to "send nothing".

Left alone on purpose:

The Bedrock-prefixed ids in `docs/integrations/openclaw.md` and `examples/openclaw/`. Bedrock carries its own model names and its own retirement schedule, and I did not verify the exact Bedrock string for the replacement, so guessing there seemed worse than leaving it.

`ACELiteLLM.from_model` still defaults `temperature=0.0`. That path is provider-agnostic and the default is right for most models behind LiteLLM, so changing it is a design call rather than a compatibility fix. Someone routing an Anthropic model through it will hit the same rejection, and I am happy to open a separate PR if you want that handled.

`benchmarks/`, `specs/` and the remaining test fixtures. Those read as records of runs and design decisions rather than code that calls the API.

I ran `pytest` on the tree before and after. Both give 446 passed and 26 failed, and the failures are the same ones either way, all from optional packages that are not installed (`mlflow`, `pydantic_settings`). `tests/test_claude_sdk_step.py` is green at 38 passed.

Retirement dates: https://platform.claude.com/docs/en/about-claude/model-deprecations

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model ids, so I am saying that up front rather than leaving you to wonder. I have not called the API to reproduce either failure, so the retirement claim rests on the published dates and the temperature claim rests on the documented parameter restriction. If you would rather handle this your own way, or would rather not get this kind of contribution at all, tell me and I will not send another.
