### PR TITLE
Put ACE_DECISIONS.md where an agent reads it without being told

### DIFF
--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -2,6 +2,14 @@
 
 <!-- Written by `knos export`. Commit this file. -->
 
+<!--
+Reading this file needs nothing installed: it is plain markdown, and a fresh
+clone picks it up as-is. The live claim/withhold server is a separate, optional
+step - `pip install knos` (Python 3.10+), which the MCP entry launches as
+`python -m knos.mcp`. Without it, everything below still reads normally.
+-->
+
+
 A second clone reads this on its first question - it is one of the decision
 records knos looks for. Nothing here is private: secrets and private paths
 never reach it.

--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -1,0 +1,23 @@
+# Decisions and current work
+
+<!-- Written by `knos export`. Commit this file. -->
+
+A second clone reads this on its first question - it is one of the decision
+records knos looks for. Nothing here is private: secrets and private paths
+never reach it.
+
+
+## Decisions
+
+- **pipeline-first is mandatory** - Do not write a function that calls multiple steps manually instead of composing them in a Pipeline, and do not inline reflection or evaluation logic instead of creating a `ReflectStep` or `EvaluateStep`.  _(AGENTS.md)_
+- **no ad-hoc concurrency** - Use `async_boundary` and `max_workers` on steps rather than reaching for `ThreadPoolExecutor` directly.  _(AGENTS.md)_
+- **respect requires/provides** - Do not bypass the contracts by accessing context fields a step has not declared in `requires`.  _(AGENTS.md)_
+- **no standalone duplicates** - Scripts that duplicate pipeline functionality without using the pipeline engine are not accepted.  _(AGENTS.md)_
+- **design decisions have a home** - `docs/design/ACE_DECISIONS.md` holds decisions and rejected alternatives; architecture is in `ACE_ARCHITECTURE.md`, the code reference in `ACE_REFERENCE.md`, the pipeline engine in `PIPELINE_DESIGN.md`.  _(AGENTS.md)_
+
+## Being worked on right now
+
+_Nothing claimed._
+
+---
+<sub>knos export. Claims lapse after 30 minutes.</sub>

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "knos": {
+      "command": "python",
+      "args": [
+        "-m",
+        "knos.mcp"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
`docs/design/ACE_DECISIONS.md` is described in `AGENTS.md` as *"design decisions and rejected alternatives."* That is the right file, and it depends on an agent knowing to open it. `.knos/decisions.md` is one of the paths a Knos-connected agent reads on its first question, so the same constraints arrive without the agent having to go looking.

**What's in the PR**

- `.knos/decisions.md` - the mandatory rules from `AGENTS.md`, each line citing its source. It does not duplicate `ACE_DECISIONS.md`; it points at it and carries the standing constraints that apply to every change.
- `.mcp.json` - one server, three tools, stdio.

**Disclosure:** I wrote Knos. It is a local MCP server - three tools, no ports, no network, no account, no model download. The record is seeded from your own docs rather than mine so it is checkable rather than promotional. Close it if a third-party entry isn't wanted; the `.knos/decisions.md` half needs no install and works as plain markdown either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)